### PR TITLE
Enable try/except; improve logging

### DIFF
--- a/databuilder/build_script.py
+++ b/databuilder/build_script.py
@@ -1,27 +1,22 @@
 from datetime import datetime
 from pathlib import Path
 import logging
+from logging.handlers import RotatingFileHandler
 from whalebuilder.utils.task_wrappers import create_and_run_tasks_from_yaml
 from whalebuilder.utils.paths import ETL_LOG_PATH, LOGS_DIR
 
 Path(LOGS_DIR).mkdir(parents=True, exist_ok=True)
-Path(ETL_LOG_PATH).touch()
-logging.getLogger("pyhive").setLevel(logging.WARNING)
-logging.getLogger("databuilder.task.task").setLevel(logging.WARNING)
+stream_handler = logging.StreamHandler()
+rotating_handler = RotatingFileHandler(str(ETL_LOG_PATH), maxBytes=50*1024*1024, backupCount=5)
 logging.basicConfig(
-    format="[%(asctime)s] %(message)s",
-    datefmt="%Y-%m-%d %H:%M:%S",
-    filename=ETL_LOG_PATH,
-    filemode="w",
+    format="%(asctime)s:%(levelname)s:%(name)s:%(message)s",
+    handlers=[rotating_handler, stream_handler],
     level=logging.INFO)
 
-
 LOGGER = logging.getLogger("whalebuilder")
-LOGGER.addHandler(logging.StreamHandler())
-
-start_time = datetime.now()
 LOGGER.info("ETL process started.")
 
+start_time = datetime.now()
 create_and_run_tasks_from_yaml()
 
 end_time = datetime.now()

--- a/databuilder/build_script.py
+++ b/databuilder/build_script.py
@@ -16,7 +16,7 @@ logging.basicConfig(
     level=logging.INFO)
 
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = logging.getLogger("whalebuilder")
 LOGGER.addHandler(logging.StreamHandler())
 
 start_time = datetime.now()

--- a/databuilder/tests/unit/utils/test_extractor_wrappers.py
+++ b/databuilder/tests/unit/utils/test_extractor_wrappers.py
@@ -10,10 +10,15 @@ from whalebuilder.models.connection_config import ConnectionConfigSchema
 from whalebuilder.engine.sql_alchemy_engine import SQLAlchemyEngine
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from whalebuilder.extractor.bigquery_metadata_extractor import BaseBigQueryExtractor
-from whalebuilder.utils.extractor_wrappers import \
-    configure_bigquery_extractors, \
-    configure_neo4j_extractors, \
-    configure_presto_extractors
+from databuilder.extractor.base_postgres_metadata_extractor import BasePostgresMetadataExtractor
+from whalebuilder.utils.extractor_wrappers import (
+    configure_bigquery_extractors,
+    configure_neo4j_extractors,
+    configure_presto_extractors,
+    configure_postgres_extractors,
+    configure_redshift_extractors,
+    configure_snowflake_extractors,
+)
 from databuilder.extractor.neo4j_extractor import Neo4jExtractor
 
 TEST_PRESTO_CONNECTION_CONFIG = ConnectionConfigSchema(
@@ -48,6 +53,16 @@ TEST_NEO4J_CONNECTION_CONFIG = ConnectionConfigSchema(
     excluded_keys=['mock_key_excluded'],
 )
 
+TEST_POSTGRES_CONNECTION_CONFIG = ConnectionConfigSchema(
+    name='test_connection',
+    username='mock_username',
+    password='mock_password',
+    uri='mock_uri',
+    port='9999',
+    metadata_source='postgres',
+    cluster='mock_cluster',
+)
+
 
 # @patch.object(SQLAlchemyEngine, '_get_connection')
 @patch.object(SQLAlchemyExtractor, '_execute_query')
@@ -72,6 +87,22 @@ def test_configure_bigquery_extractor(*mock_settings):
     extractor = extractors[0]
     scoped_conf = Scoped.get_scoped_conf(conf, extractor.get_scope())
     assert extractor.init(scoped_conf) == None
+
+
+@patch.object(SQLAlchemyExtractor, '_execute_query')
+@patch.object(SQLAlchemyExtractor, '_get_connection')
+def test_configure_postgres_extractor(*mock_settings):
+    """
+    Test that the extractor can initialize.
+    """
+    for configurer in [
+            configure_postgres_extractors,
+            configure_redshift_extractors]:
+        extractors, conf = \
+            configurer(TEST_POSTGRES_CONNECTION_CONFIG)
+        extractor = extractors[0]
+        scoped_conf = Scoped.get_scoped_conf(conf, extractor.get_scope())
+        assert extractor.init(scoped_conf) == None
 
 
 @patch.object(Neo4jExtractor, '_get_driver')

--- a/databuilder/whalebuilder/task/__init__.py
+++ b/databuilder/whalebuilder/task/__init__.py
@@ -1,8 +1,11 @@
 import csv
+import logging
 import os
 from datetime import datetime
 from databuilder.task.task import DefaultTask
 from whalebuilder.utils.paths import TABLE_COUNT_PATH
+
+LOGGER = logging.getLogger(__name__)
 
 
 class WhaleTask(DefaultTask):
@@ -32,6 +35,7 @@ class WhaleTask(DefaultTask):
             self._closer.close()
 
     def save_stats(self):
+        LOGGER.info("Saving task-level statistics.")
         has_headers = os.path.isfile(TABLE_COUNT_PATH)
 
         with open(TABLE_COUNT_PATH, "a") as csvfile:


### PR DESCRIPTION
* Sometimes watermark/usage/etc. extractors can fail because of insufficient permissions (e.g. see the current state of the [whale bigquery demo](https://github.com/dataframehq/whale-bigquery-public-data/actions)). Wrapped all non-metadata extraction tasks in a `try/except` to allow all remaining clean-up work to pass through.
* Improve logging: in the current state of the app, we were (a) not surfacing module-level logs to stdout or cron.log and (b) had no expiration for these logs. This PR modifies the build_script.py file so both of these issues are fixed. For (b), I've used a `RotatingFileHandler`, so the last 5 backups are saved up to ~50 mb each. This is probably overkill, but best to have a safeguard in place.
* Add a missing postgres/redshift test.