### PR TITLE
feat: add glue support.

### DIFF
--- a/cli/src/warehouse.rs
+++ b/cli/src/warehouse.rs
@@ -59,7 +59,7 @@ impl fmt::Display for MetadataSource {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
             MetadataSource::Bigquery => write!(f, "Bigquery"),
-            MetadataSource::Glue=> write!(f, "Glue"),
+            MetadataSource::Glue => write!(f, "Glue"),
             MetadataSource::Hive => write!(f, "Hive"),
             MetadataSource::HiveMetastore => write!(f, "Hive Metastore"),
             MetadataSource::Postgres => write!(f, "Postgres"),
@@ -324,7 +324,6 @@ impl GenericWarehouse {
     }
 }
 
-
 #[derive(Serialize, Deserialize)]
 pub struct Glue {
     pub name: String,
@@ -336,7 +335,7 @@ impl Glue {
         // name
         let name: String = get_name();
 
-        let git_header = format!("Glue requires no further configuration. We will let boto3 handle the connection configuration.");
+        let git_header = "Glue requires no further configuration. We will let boto3 handle the connection configuration.";
         println!("{}", git_header);
 
         let compiled_config = Glue {
@@ -354,8 +353,6 @@ impl Glue {
         );
     }
 }
-
-
 
 #[derive(Serialize, Deserialize)]
 pub struct HiveMetastore {

--- a/pipelines/requirements.txt
+++ b/pipelines/requirements.txt
@@ -1,4 +1,5 @@
 amundsen-databuilder==3.3.2
+boto3
 google-api-python-client==1.10.0
 google-auth-httplib2==0.0.4
 google-auth-oauthlib==0.4.1

--- a/pipelines/tests/unit/utils/test_extractor_wrappers.py
+++ b/pipelines/tests/unit/utils/test_extractor_wrappers.py
@@ -1,3 +1,4 @@
+import boto3
 import google
 import googleapiclient
 import google_auth_httplib2
@@ -13,6 +14,7 @@ from whale.extractor.bigquery_metadata_extractor import BaseBigQueryExtractor
 from databuilder.extractor.base_postgres_metadata_extractor import BasePostgresMetadataExtractor
 from whale.utils.extractor_wrappers import (
     configure_bigquery_extractors,
+    configure_glue_extractors,
     configure_neo4j_extractors,
     configure_presto_extractors,
     configure_postgres_extractors,
@@ -39,6 +41,11 @@ TEST_BIGQUERY_CONNECTION_CONFIG = ConnectionConfigSchema(
     project_id='mock_project_id',
     page_size=10,
     filter_key='mock_filter_key'
+)
+
+TEST_GLUE_CONNECTION_CONFIG = ConnectionConfigSchema(
+    metadata_source='glue',
+    filters='mock_filter',
 )
 
 TEST_NEO4J_CONNECTION_CONFIG = ConnectionConfigSchema(
@@ -84,6 +91,18 @@ def test_configure_bigquery_extractor(*mock_settings):
     """
     extractors, conf = \
         configure_bigquery_extractors(TEST_BIGQUERY_CONNECTION_CONFIG)
+    extractor = extractors[0]
+    scoped_conf = Scoped.get_scoped_conf(conf, extractor.get_scope())
+    assert extractor.init(scoped_conf) == None
+
+
+@patch.object(boto3, 'client')
+def test_configure_glue_extractor(*mock_settings):
+    """
+    Test that the extractor can initialize.
+    """
+    extractors, conf = \
+        configure_glue_extractors(TEST_GLUE_CONNECTION_CONFIG)
     extractor = extractors[0]
     scoped_conf = Scoped.get_scoped_conf(conf, extractor.get_scope())
     assert extractor.init(scoped_conf) == None

--- a/pipelines/tests/unit/utils/test_task_wrappers.py
+++ b/pipelines/tests/unit/utils/test_task_wrappers.py
@@ -23,3 +23,7 @@ def test_run(mock_execution, get_connection):
 
 def test_pull_without_files(mock_file_structure):
     pull()
+
+
+def test_pull_glue(mock_file_structure):
+    pull()

--- a/pipelines/tests/unit/utils/test_task_wrappers.py
+++ b/pipelines/tests/unit/utils/test_task_wrappers.py
@@ -23,7 +23,3 @@ def test_run(mock_execution, get_connection):
 
 def test_pull_without_files(mock_file_structure):
     pull()
-
-
-def test_pull_glue(mock_file_structure):
-    pull()

--- a/pipelines/whale/utils/extractor_wrappers.py
+++ b/pipelines/whale/utils/extractor_wrappers.py
@@ -15,6 +15,7 @@ from whale.extractor.snowflake_metadata_extractor \
 from whale.extractor.metric_runner import MetricRunner
 from whale.engine.sql_alchemy_engine import SQLAlchemyEngine
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
+from databuilder.extractor.glue_extractor import GlueExtractor
 from databuilder.extractor.hive_table_metadata_extractor import HiveTableMetadataExtractor
 from databuilder.extractor.postgres_metadata_extractor import PostgresMetadataExtractor
 from databuilder.extractor.redshift_metadata_extractor import RedshiftMetadataExtractor
@@ -67,6 +68,20 @@ def configure_bigquery_extractors(connection: ConnectionConfigSchema):
     extractors = [extractor, watermark_extractor]
     extractors, conf = add_metrics(extractors, conf, connection)
 
+    return extractors, conf
+
+
+def configure_glue_extractors(connection: ConnectionConfigSchema):
+    Extractor = GlueExtractor
+    extractor = Extractor()
+    scope = extractor.get_scope()
+
+    conf = ConfigFactory.from_dict({
+        f"{scope}.{Extractor.CLUSTER_KEY}": connection.cluster,
+        f"{scope}.{Extractor.FILTER_KEY}": connection.filter_key,
+    })
+
+    extractors = [extractor]
     return extractors, conf
 
 

--- a/pipelines/whale/utils/task_wrappers.py
+++ b/pipelines/whale/utils/task_wrappers.py
@@ -18,6 +18,7 @@ from whale.utils.config import (
 
 from whale.utils.extractor_wrappers import (
     configure_bigquery_extractors,
+    configure_glue_extractors,
     configure_hive_metastore_extractors,
     configure_neo4j_extractors,
     configure_postgres_extractors,
@@ -70,13 +71,14 @@ def pull():
         connection = ConnectionConfigSchema(**raw_connection_dict)
 
         metadata_source_dict = {
-            "hivemetastore": configure_hive_metastore_extractors,
-            "presto": configure_presto_extractors,
-            "neo4j": configure_neo4j_extractors,
             "bigquery": configure_bigquery_extractors,
-            "snowflake": configure_snowflake_extractors,
+            "glue": configure_glue_extractors,
+            "hivemetastore": configure_hive_metastore_extractors,
+            "neo4j": configure_neo4j_extractors,
             "postgres": configure_postgres_extractors,
+            "presto": configure_presto_extractors,
             "redshift": configure_redshift_extractors,
+            "snowflake": configure_snowflake_extractors,
         }
 
         if connection.metadata_source == 'build_script':


### PR DESCRIPTION
Addresses this: https://github.com/dataframehq/whale/issues/46

* Uses the amundsendatabuilder `GlueExtractor` to scrape directly from aws glue using the boto3 API. Creates a dedicated wrapper that handles this.
* Adds boto3 as a default requirement.
* Adds a test for the new configurer.