### PR TITLE
 chore: cargo-ci should only run when cli/ is modified #58 

### DIFF
--- a/.github/workflows/cargo-ci.yml
+++ b/.github/workflows/cargo-ci.yml
@@ -1,11 +1,14 @@
 ---
 # shamelessly lifted from https://github.com/actions-rs/meta/blob/master/recipes/quickstart.md
+name: Cargo-CI
 
 on:
-  - push
-  - pull_request
-
-name: Cargo-CI
+  push:
+    paths:
+    - "cli/**"
+  pull_request:
+    paths:
+    - "cli/**"
 
 jobs:
   fmt:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,12 @@
 name: CI
 
-on: [push]
+on:
+  push:
+    paths:
+    - "pipelines/**"
+  pull_request:
+    paths:
+    - "pipelines/**"
 
 jobs:
   build:


### PR DESCRIPTION
Could be more selective about branch names 🤷.
Quickly tested in my fork and it does what I expect however I'm not too familiar with workflows.