### PR TITLE
fix: crontab failed to register

### DIFF
--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -255,7 +255,7 @@ Fetching and rebasing local changes from github.");
 
             let whale_cron_expression = format!("{} {}", cron_string, whale_etl_command);
             let scheduler_command = format!(
-                "(crontab -l | fgrep -v \"{}\"; echo \"{}\") | crontab -",
+                "(crontab -l | grep -v \"{}\"; echo \"{}\") | crontab -",
                 whale_etl_command, whale_cron_expression
             );
 

--- a/cli/src/utils.rs
+++ b/cli/src/utils.rs
@@ -53,9 +53,9 @@ pub fn is_valid_cron_expression(expression: &str) -> bool {
 
 pub fn is_cron_expression_registered() -> bool {
     let result = Command::new("sh")
-        .args(&["-c", "crontab -l | fgrep \"wh pull\""])
+        .args(&["-c", "crontab -l | grep -E \"wh|whale pull\""])
         .output()
-        .expect("Fgrep failed.");
+        .expect("grep failed.");
     let stdout = String::from_utf8(result.stdout).unwrap();
 
     !stdout.trim().is_empty()


### PR DESCRIPTION
Covers https://github.com/dataframehq/whale/issues/63

Looks like fgrep is deprecated (1,2) so I've replaced it with 'just' grep.
grep -E is then used like `grep -E \"wh|whale pull` to match wh or whale
followed by pull.

I've tested this on a mac and an Ubuntu container with echo-ed text and the whale generated crontab entry.

sidenote: think it's probably worth creating an issue to increase the rust test coverage.

1. https://unix.stackexchange.com/questions/383448/why-is-direct-invocation-as-either-egrep-or-fgrep-deprecated
2. https://linuxhandbook.com/grep-egrep-fgrep/