### PR TITLE
chore: Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,18 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# 4 space indentation
+[*.py]
+indent_style = space
+indent_size = 4
+charset = utf-8
+
+# Tab indentation (no size specified)
+[Makefile]
+indent_style = tab

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # How to contribute
 👋 **Hello future whale committer!** We are so excited that you're interested in contributing to whale.
 
-Whale welcomes all contributions and corrections. Before contributing, please make sure you have read the guidelines below. 
+Whale welcomes all contributions and corrections. Before contributing, please make sure you have read the guidelines below.
 
 ## 📘 General instructions
 Pull requests are the easiest and preferred method to contribute to any repo at Github.
 
-1. Fork this repository, or update it if you've already forked it before. 
+1. Fork this repository, or update it if you've already forked it before.
 2. Create a new branch specific to the issue you are working on with `git checkout -b feature_name`. This action will separate the new feature from any other changes you may do and will make it easier to edit or amend (read more [here](https://guides.github.com/introduction/flow/)).
 3. If necessary (use your best judgment), test the feature with a local installation of whale (see [here](https://docs.whale.cx/#all-others) for installation instructions).
 4. Add your files on the new branch.
@@ -20,13 +20,13 @@ Please check the issues tab to find something to contribute with. Before startin
 If someone has already commented about their intentions to fix the issue but nothing has been submitted after 2 or 3 weeks, then it's acceptable to still pick up the issue but make sure to leave a comment.
 
 ## 📝 Working on new issues
-If you have detected a new issue that needs to be fixed or you would like to add more functionalities please make sure to create an issue. 
+If you have detected a new issue that needs to be fixed or you would like to add more functionalities please make sure to create an issue.
 Before you submit a new issue please make sure that:
-- Is a request that has not been done yet. Check closed issues as well. 
+- Is a request that has not been done yet. Check closed issues as well.
 - Isn't related to anything that provides an illegal service (e.g. piracy, malware, threatening material, spam, etc.).
 
 If you are in doubt, feel free to submit it and we'll have a look.
 
-Thanks for reading through to the end, and welcome to the team! :whale: 
+Thanks for reading through to the end, and welcome to the team! :whale:
 
 *To stay up to date on discussions with other contributors, join the [**#contributors** channel](https://talk-whale.slack.com/archives/C01DHUR40U9) on slack ([**join our community first**](https://join.slack.com/t/talk-whale/shared_invite/zt-i2rayu1u-fljCh7reVstTBOtaH1n1xA) if you haven't already done so).*

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 * Automatically index all of the tables in your warehouse as plain markdown files -- so they're easily versionable, searchable, and editable either locally or through a remote git server.
 * Search for tables and documentation through the CLI or through a git remote server like Github.
 * Define and schedule basic metric calculations (in beta).
-* Run quality tests and systematically monitor anomalies (in roadmap). 
+* Run quality tests and systematically monitor anomalies (in roadmap).
 
 😁 [**Join the discussion on slack.**](https://join.slack.com/t/talk-whale/shared_invite/zt-i2rayu1u-fljCh7reVstTBOtaH1n1xA)
 


### PR DESCRIPTION
Targets https://github.com/dataframehq/whale/issues/72

[Editorconfig](https://editorconfig.org/) is a tool designed to help
maintain coding standards for multiple developers working on the same
project with different editors. I've added a simple config file in this PR 
and applied the rules to the CONTRIBUTING.md and README.md, note
removal of trailing whitespace.

Perhaps we should document a setup process for contributing? Which
tools folks will have to install and how, part of this should include the above,
although some editors ship with support (VSCode does not)