### PR TITLE
feat: added labels and tags fetching for BigQuery

### DIFF
--- a/pipelines/requirements.txt
+++ b/pipelines/requirements.txt
@@ -22,6 +22,7 @@ google-auth-httplib2==0.0.4
 google-auth-oauthlib==0.4.1
 google-cloud-bigquery==2.2.0
 google-cloud-core==1.4.3
+google-cloud-datacatalog==2.0.0
 google-cloud-spanner==1.19.0
 google-crc32c==1.0.0
 google-resumable-media==1.1.0

--- a/pipelines/tests/unit/extractor/test_bigquery_metadata_extractor.py
+++ b/pipelines/tests/unit/extractor/test_bigquery_metadata_extractor.py
@@ -300,6 +300,7 @@ TAGS = {
         },
     ]
 }
+NO_TAGS = {}
 
 
 try:
@@ -531,6 +532,23 @@ class TestBigQueryMetadataExtractor(unittest.TestCase):
                 "templateDisplayName": "demo-tag",
             },
         )
+
+    @patch("whale.extractor.base_bigquery_extractor.build")
+    @patch("whale.extractor.base_bigquery_extractor.datacatalog_v1")
+    def test_table_without_tags(self, mock_datacatalogue, mock_bigquery):
+        mock_bigquery.return_value = MockBigQueryClient(
+            ONE_DATASET, ONE_TABLE, TABLE_DATA
+        )
+        mock_datacatalogue.DataCatalogClient.return_value = MockDataCatalogClient(
+            ENTRY, NO_TAGS
+        )
+        extractor = BigQueryMetadataExtractor()
+        extractor.init(
+            Scoped.get_scoped_conf(conf=self.conf, scope=extractor.get_scope())
+        )
+        result = extractor.extract()
+
+        self.assertEqual(result.tags, None)
 
     @patch("whale.extractor.base_bigquery_extractor.build")
     @patch("whale.extractor.base_bigquery_extractor.datacatalog_v1")

--- a/pipelines/whale/extractor/base_bigquery_extractor.py
+++ b/pipelines/whale/extractor/base_bigquery_extractor.py
@@ -4,6 +4,7 @@ import os
 import re
 from collections import namedtuple
 
+from google.cloud import datacatalog_v1
 import google.oauth2.service_account
 import google_auth_httplib2
 from googleapiclient.discovery import build
@@ -28,6 +29,7 @@ class BaseBigQueryExtractor(Extractor):
     PAGE_SIZE_KEY = "page_size"
     FILTER_KEY = "filter"
     _DEFAULT_SCOPES = [
+        "https://www.googleapis.com/auth/cloud-platform",
         "https://www.googleapis.com/auth/bigquery.readonly",
     ]
     DEFAULT_PAGE_SIZE = 300
@@ -79,8 +81,8 @@ class BaseBigQueryExtractor(Extractor):
         self.bigquery_service = build(
             "bigquery", "v2", http=authed_http, cache_discovery=False
         )
-        self.logging_service = build(
-            "logging", "v2", http=authed_http, cache_discovery=False
+        self.datacatalog_service = datacatalog_v1.DataCatalogClient(
+            credentials=credentials
         )
         self.iter = iter(self._iterate_over_tables())
 

--- a/pipelines/whale/extractor/bigquery_metadata_extractor.py
+++ b/pipelines/whale/extractor/bigquery_metadata_extractor.py
@@ -104,9 +104,9 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
                                 )
 
                 table_tag = None
-                if "tags" in tags_dict:
+                if tags_dict and "tags" in tags_dict:
                     for tag in tags_dict["tags"]:
-                        if not "column" in tag:
+                        if "column" not in tag:
                             table_tag = tag
 
                 table_meta = TableMetadata(
@@ -137,7 +137,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
             col_name = column["name"]
 
         tags = None
-        if "tags" in tags_dict:
+        if tags_dict and "tags" in tags_dict:
             for tag in tags_dict["tags"]:
                 if "column" in tag:
                     if tag["column"] == col_name:

--- a/pipelines/whale/extractor/bigquery_metadata_extractor.py
+++ b/pipelines/whale/extractor/bigquery_metadata_extractor.py
@@ -1,4 +1,5 @@
 import logging
+import json
 from collections import namedtuple
 
 from pyhocon import ConfigTree  # noqa: F401
@@ -67,6 +68,26 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
                     .execute(num_retries=BigQueryMetadataExtractor.NUM_RETRIES)
                 )
 
+                tags_dict = None
+                try:
+                    # Fetch entry for given linked_resource
+                    entry = self.datacatalog_service.lookup_entry(
+                        request={
+                            "linked_resource": f"//bigquery.googleapis.com/projects/{tableRef['projectId']}/datasets/{tableRef['datasetId']}/tables/{tableRef['tableId']}"
+                        }
+                    )
+                    if not isinstance(entry, dict):
+                        entry_json = entry.__class__.to_json(entry)
+                        entry = json.loads(entry_json)
+
+                    # Fetch tags for given entry
+                    tags = self.datacatalog_service.list_tags(
+                        request={"parent": entry["name"]}
+                    )
+                    tags_dict = dict(tags)
+                except Exception as e:
+                    LOGGER.warning(f"Error fetching tags from Data Catalog: {e}")
+
                 cols = []
                 if self._is_table_match_regex(tableRef):
                     # BigQuery tables also have interesting metadata about
@@ -79,8 +100,14 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
                             total_cols = 0
                             for column in schema["fields"]:
                                 total_cols = self._iterate_over_cols(
-                                    "", column, cols, total_cols + 1
+                                    tags_dict, "", column, cols, total_cols + 1
                                 )
+
+                table_tag = None
+                if "tags" in tags_dict:
+                    for tag in tags_dict["tags"]:
+                        if not "column" in tag:
+                            table_tag = tag
 
                 table_meta = TableMetadata(
                     database="bigquery",
@@ -90,17 +117,31 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
                     description=table.get("description", ""),
                     columns=cols,
                     is_view=table["type"] == "VIEW",
+                    tags=table_tag,
+                    labels=table.get("labels", ""),
                 )
 
                 yield (table_meta)
 
     def _iterate_over_cols(
-        self, parent: str, column: str, cols: List[ColumnMetadata], total_cols: int
+        self,
+        tags_dict: dict,
+        parent: str,
+        column: str,
+        cols: List[ColumnMetadata],
+        total_cols: int,
     ) -> int:
         if len(parent) > 0:
             col_name = "{parent}.{field}".format(parent=parent, field=column["name"])
         else:
             col_name = column["name"]
+
+        tags = None
+        if "tags" in tags_dict:
+            for tag in tags_dict["tags"]:
+                if "column" in tag:
+                    if tag["column"] == col_name:
+                        tags = tag
 
         if column["type"] == "RECORD":
             col = ColumnMetadata(
@@ -108,11 +149,14 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
                 description=column.get("description", ""),
                 col_type=column["type"],
                 sort_order=total_cols,
+                tags=tags,
             )
             cols.append(col)
             total_cols += 1
             for field in column["fields"]:
-                total_cols = self._iterate_over_cols(col_name, field, cols, total_cols)
+                total_cols = self._iterate_over_cols(
+                    tags_dict, col_name, field, cols, total_cols
+                )
             return total_cols
         else:
             col = ColumnMetadata(
@@ -120,6 +164,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
                 description=column.get("description", ""),
                 col_type=column["type"],
                 sort_order=total_cols,
+                tags=tags,
             )
             cols.append(col)
             return total_cols + 1

--- a/pipelines/whale/models/table_metadata.py
+++ b/pipelines/whale/models/table_metadata.py
@@ -1,6 +1,6 @@
 import copy
 
-from typing import Iterable, List, Optional
+from typing import Dict, Iterable, List, Optional, Union
 
 
 class ColumnMetadata:
@@ -12,7 +12,7 @@ class ColumnMetadata:
         description: Optional[str],
         col_type: str,
         sort_order: int,
-        tags: Optional[List[str]] = None,
+        tags: Optional[Union[List[Dict], List[str]]] = None,
         is_partition_column: Optional[bool] = None,
     ):
         # type: (...) -> None
@@ -31,11 +31,12 @@ class ColumnMetadata:
 
     def __repr__(self):
         # type: () -> str
-        return "ColumnMetadata({!r}, {!r}, {!r}, {!r}, {!r})".format(
+        return "ColumnMetadata({!r}, {!r}, {!r}, {!r}, {!r}, {!r})".format(
             self.name,
             self.description,
             self.type,
             self.sort_order,
+            self.tags,
             self.is_partition_column,
         )
 
@@ -62,7 +63,8 @@ class TableMetadata(object):
         columns: Iterable[ColumnMetadata] = None,
         is_view: bool = False,
         markdown_blob: str = "",
-        tags: Optional[List] = None,
+        tags: Optional[Union[List[Dict], List[str]]] = None,
+        labels: Optional[Union[Dict, List[str]]] = None,
         description_source: Optional[str] = None,
         **kwargs
     ):
@@ -76,6 +78,7 @@ class TableMetadata(object):
         :param columns:
         :param is_view:
         :param tags:
+        :param labels:
         :param kwargs:
         """
         self.database = database
@@ -92,13 +95,14 @@ class TableMetadata(object):
         if isinstance(tags, list):
             tags = [tag.lower().strip() for tag in tags]
         self.tags = tags
+        self.labels = labels
 
         if kwargs:
             self.attrs = copy.deepcopy(kwargs)
 
     def __repr__(self):
         # type: () -> str
-        return "TableMetadata({!r}, {!r}, {!r}, {!r} " "{!r}, {!r}, {!r}, {!r})".format(
+        return "TableMetadata({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})".format(
             self.database,
             self.cluster,
             self.schema,
@@ -107,6 +111,7 @@ class TableMetadata(object):
             self.columns,
             self.is_view,
             self.tags,
+            self.labels,
         )
 
     def _get_table_key(self):

--- a/pipelines/whale/utils/__init__.py
+++ b/pipelines/whale/utils/__init__.py
@@ -74,13 +74,13 @@ def transfer_manifest(tmp_manifest_path):
     if os.path.exists(tmp_manifest_path):
         os.rename(tmp_manifest_path, paths.MANIFEST_PATH)
     else:
-        LOGGER.warn(f"No tmp manifest created at path: {tmp_manifest_path}")
+        LOGGER.warning(f"No tmp manifest created at path: {tmp_manifest_path}")
 
 
 def copy_manifest(tmp_manifest_path):
     if os.path.exists(tmp_manifest_path):
         shutil.copy(tmp_manifest_path, paths.MANIFEST_PATH)
     else:
-        LOGGER.warn(
+        LOGGER.warning(
             f"No tmp manifest copied from {tmp_manifest_path} to {paths.MANIFEST_PATH}"
         )


### PR DESCRIPTION
- Using `datacatalog_v1` Python client to fetch tags for a given BQ table
- Added the tags data to `TableMetadata` and `ColumnMetadata`  where appropriate
- Also added labels to `TableMetadata`