### PR TITLE
Add test to metric runner

### DIFF
--- a/docs/features/metrics.md
+++ b/docs/features/metrics.md
@@ -1,6 +1,6 @@
 # Metrics
 
-Whale supports automatic barebones metric definition and scheduled calculation. Metrics are defined by creating a ```````metrics```` block, as explained below. Any metrics defined in this way will be automatically be scheduled alongside the metadata scraping job.
+Whale supports automatic barebones metric definition and scheduled calculation. Metrics are defined by creating a ```````metrics```` block, as explained below. Any metric defined in this way will automatically be scheduled alongside the metadata scraping job.
 
 ## Basic usage
 
@@ -61,7 +61,7 @@ distinct-registrations:
 ```
 ```
 
-These metrics will be scheduled, with the latest calculations injected into the programmatically portion of the table stub. An example is shown below:
+These metrics will be scheduled, with the latest calculations injected into the programmatic portion of the table stub. An example is shown below:
 
 ```text
 schema.table

--- a/pipelines/tests/unit/extractor/test_glue_extractor.py
+++ b/pipelines/tests/unit/extractor/test_glue_extractor.py
@@ -94,7 +94,7 @@ class TestGlueExtractor(unittest.TestCase):
                     ColumnMetadata("ds", None, "varchar", 5),
                     ColumnMetadata(
                         "partition_key1", "description of partition_key1", "string", 6
-                   ),
+                    ),
                 ],
                 False,
             )
@@ -147,9 +147,9 @@ class TestGlueExtractor(unittest.TestCase):
             ]
 
             extractor = GlueExtractor()
-            conf = ConfigFactory.from_dict({
-                GlueExtractor.IS_LOCATION_PARSING_ENABLED_KEY: True
-            })
+            conf = ConfigFactory.from_dict(
+                {GlueExtractor.IS_LOCATION_PARSING_ENABLED_KEY: True}
+            )
             extractor.init(conf)
             actual = extractor.extract()
             expected = TableMetadata(
@@ -172,7 +172,7 @@ class TestGlueExtractor(unittest.TestCase):
                     ColumnMetadata("ds", None, "varchar", 5),
                     ColumnMetadata(
                         "partition_key1", "description of partition_key1", "string", 6
-                   ),
+                    ),
                 ],
                 False,
             )

--- a/pipelines/tests/unit/extractor/test_metric_runner.py
+++ b/pipelines/tests/unit/extractor/test_metric_runner.py
@@ -1,0 +1,70 @@
+import logging
+import os
+import unittest
+import pytest
+
+from mock import patch
+from pyhocon import ConfigFactory
+from databuilder import Scoped
+
+from whale.models.metric_value import MetricValue
+from whale.extractor.metric_runner import MetricRunner
+from whale.utils import paths
+from whale.models.table_metadata import TableMetadata
+from whale.loader import whale_loader
+from whale.engine.sql_alchemy_engine import SQLAlchemyEngine
+
+
+logging.basicConfig(level=logging.INFO)
+
+
+@patch.object(SQLAlchemyEngine, "_get_connection")
+@patch.object(SQLAlchemyEngine, "execute")
+def test_sends_sql_query_to_sql_alchemy(mock_execution, get_connection, tmp_path):
+    database = "mock_database"
+    schema = "mock_schema"
+    table = "mock_table"
+    table_stub_path = os.path.join(tmp_path, database, f"{schema}.{table}.md")
+
+    loader_config = ConfigFactory.from_dict(
+        {"table_stub_paths": [table_stub_path], "base_directory": tmp_path}
+    )
+
+    extractor_config = ConfigFactory.from_dict(
+        {
+            MetricRunner.DATABASE_KEY: database,
+            "table_stub_paths": [table_stub_path],
+        }
+    )
+
+    record = TableMetadata(
+        database=database,
+        cluster=None,
+        schema=schema,
+        name=table,
+    )
+
+    loader = whale_loader.WhaleLoader()
+    loader.init(loader_config)
+    loader.load(record)
+
+    sql_query = """select count(distinct id) from {schema}.{table} where id is null"""
+
+    add_metrics_to_markdown(table_stub_path, "null-ids", sql_query)
+
+    extractor = MetricRunner()
+    extractor.init(extractor_config)
+    extractor.extract()
+    mock_execution.assert_called_once_with(sql_query, is_dict_return_enabled=False)
+
+
+def add_metrics_to_markdown(file_path, metric_name, sql_query):
+
+    with open(file_path, "a") as f:
+        f.write(
+            f"""
+```metrics
+{metric_name}:
+  sql: |
+    {sql_query}"""
+        )

--- a/pipelines/whale/engine/sql_alchemy_engine.py
+++ b/pipelines/whale/engine/sql_alchemy_engine.py
@@ -16,14 +16,6 @@ class SQLAlchemyEngine(Engine):
     MODEL_CLASS_KEY = "model_class"
     CREDENTIALS_PATH_KEY = "credentials_path"
 
-    DEFAULT_CONFIG = ConfigFactory.from_dict(
-        {
-            CONN_STRING_KEY: None,
-            MODEL_CLASS_KEY: None,
-            CREDENTIALS_PATH_KEY: None,
-        }
-    )
-
     def init(self, conf: ConfigTree):
         """
         Establish connection, import data model class (if provided)

--- a/pipelines/whale/extractor/metric_runner.py
+++ b/pipelines/whale/extractor/metric_runner.py
@@ -58,6 +58,7 @@ class MetricRunner(SQLAlchemyEngine):
 
     def _find_all_table_stub_paths(self) -> list:
         try:
+            # TODO: Translate this into Python code
             results = subprocess.check_output(
                 f"grep -l '```metrics' ~/.whale/metadata/{self.database}/* -d skip",
                 shell=True,
@@ -125,7 +126,7 @@ class MetricRunner(SQLAlchemyEngine):
                         )
 
                     except:
-                        LOGGER.warn(
+                        LOGGER.warning(
                             f"Failed execution of metric: {metric_name} in {table_stub_path}. Continuing."
                         )
 


### PR DESCRIPTION
This PR adds test coverage for sending metric SQL code to SQLAlchemy.
In addition I added some improvements to the documentation.