### PR TITLE
Adding alerts on Slack to metrics

### DIFF
--- a/pipelines/requirements.txt
+++ b/pipelines/requirements.txt
@@ -65,6 +65,7 @@ retrying==1.3.3
 rsa==4.6
 s3transfer==0.3.3
 six==1.15.0
+slack-sdk==3.0.0
 snowflake-connector-python==2.3.2
 snowflake-sqlalchemy==1.2.3
 SQLAlchemy==1.3.19

--- a/pipelines/tests/unit/extractor/test_metric_runner.py
+++ b/pipelines/tests/unit/extractor/test_metric_runner.py
@@ -2,69 +2,211 @@ import logging
 import os
 import unittest
 import pytest
+import yaml
+import tempfile
 
-from mock import patch
+from slack_sdk import WebClient
+from mock import patch, call
 from pyhocon import ConfigFactory
 from databuilder import Scoped
 
-from whale.models.metric_value import MetricValue
+from whale.models.metric_value import SlackAlert
 from whale.extractor.metric_runner import MetricRunner
 from whale.utils import paths
 from whale.models.table_metadata import TableMetadata
 from whale.loader import whale_loader
 from whale.engine.sql_alchemy_engine import SQLAlchemyEngine
+from whale.utils.markdown_delimiters import DEFINED_METRICS_DELIMITER
 
 
-logging.basicConfig(level=logging.INFO)
-
-
+@patch.object(WebClient, "chat_postMessage")
 @patch.object(SQLAlchemyEngine, "_get_connection")
 @patch.object(SQLAlchemyEngine, "execute")
-def test_sends_sql_query_to_sql_alchemy(mock_execution, get_connection, tmp_path):
-    database = "mock_database"
-    schema = "mock_schema"
-    table = "mock_table"
-    table_stub_path = os.path.join(tmp_path, database, f"{schema}.{table}.md")
+class TestMetricRunner(unittest.TestCase):
+    def setUp(self) -> None:
+        logging.basicConfig(level=logging.INFO)
+        self.database = "mock_database"
+        self.schema = "mock_schema"
+        self.table = "mock_table"
 
-    loader_config = ConfigFactory.from_dict(
-        {"table_stub_paths": [table_stub_path], "base_directory": tmp_path}
-    )
-
-    extractor_config = ConfigFactory.from_dict(
-        {
-            MetricRunner.DATABASE_KEY: database,
-            "table_stub_paths": [table_stub_path],
-        }
-    )
-
-    record = TableMetadata(
-        database=database,
-        cluster=None,
-        schema=schema,
-        name=table,
-    )
-
-    loader = whale_loader.WhaleLoader()
-    loader.init(loader_config)
-    loader.load(record)
-
-    sql_query = """select count(distinct id) from {schema}.{table} where id is null"""
-
-    add_metrics_to_markdown(table_stub_path, "null-ids", sql_query)
-
-    extractor = MetricRunner()
-    extractor.init(extractor_config)
-    extractor.extract()
-    mock_execution.assert_called_once_with(sql_query, is_dict_return_enabled=False)
-
-
-def add_metrics_to_markdown(file_path, metric_name, sql_query):
-
-    with open(file_path, "a") as f:
-        f.write(
-            f"""
-```metrics
-{metric_name}:
-  sql: |
-    {sql_query}"""
+        tmp_path = tempfile.NamedTemporaryFile()
+        self.table_stub_path = os.path.join(
+            tmp_path.name, self.database, f"{self.schema}.{self.table}.md"
         )
+
+        self.loader_config = ConfigFactory.from_dict(
+            {
+                "table_stub_paths": [self.table_stub_path],
+                "base_directory": tmp_path.name,
+            }
+        )
+
+        self.extractor_config = ConfigFactory.from_dict(
+            {
+                MetricRunner.DATABASE_KEY: self.database,
+                "table_stub_paths": [self.table_stub_path],
+            }
+        )
+
+        self.record = TableMetadata(
+            database=self.database,
+            cluster=None,
+            schema=self.schema,
+            name=self.table,
+        )
+
+    @pytest.fixture(autouse=True)
+    def mock_env_token(self, monkeypatch):
+        monkeypatch.setenv("WHALE_SLACK_TOKEN", "test-token")
+
+    def test_sends_sql_query_to_sql_alchemy(
+        self, mock_execution, get_connection, mock_slack_client
+    ) -> None:
+        mock_execution.return_value = [(0,)]
+
+        mock_slack_client.return_value = {"message": {"text": "Placeholder"}}
+
+        loader = whale_loader.WhaleLoader()
+        loader.init(self.loader_config)
+        loader.load(self.record)
+
+        sql_query = f"select count(distinct id) from {self.schema}.{self.table} where id is null"
+
+        slack_alerts = [
+            SlackAlert(
+                condition=">0",
+                message=f"Nulls found in {self.schema}.{self.table} column id.",
+                channels=["#data-monitoring", "@bob"],
+            ),
+        ]
+
+        self.add_metrics_and_alerts_to_markdown("null-ids", sql_query, slack_alerts)
+
+        extractor = MetricRunner()
+        extractor.init(self.extractor_config)
+        extractor.extract()
+        mock_execution.assert_called_once_with(
+            f" | {sql_query}", is_dict_return_enabled=False
+        )
+
+    def test_sends_alerts_to_slack_sdk(
+        self,
+        mock_execution,
+        get_connection,
+        mock_slack_client,
+    ):
+        mock_execution.return_value = [(100,)]
+
+        loader = whale_loader.WhaleLoader()
+        loader.init(self.loader_config)
+        loader.load(self.record)
+
+        sql_query = f"select count(distinct id) from {self.schema}.{self.table} where id is null"
+        alert_message = f"Nulls found in {self.schema}.{self.table} column id."
+
+        slack_alerts = [
+            SlackAlert(
+                condition=">0",
+                message=alert_message,
+                channels=["#data-monitoring", "@bob"],
+            ),
+            SlackAlert(
+                condition=">50",
+                message=alert_message,
+                channels=["#incident-room", "@joseph"],
+            ),
+        ]
+
+        self.add_metrics_and_alerts_to_markdown("null-ids", sql_query, slack_alerts)
+
+        mock_slack_client.return_value = {"message": {"text": alert_message}}
+
+        extractor = MetricRunner()
+        extractor.init(self.extractor_config)
+
+        results = extractor.extract()
+
+        calls = [
+            call(channel="#data-monitoring", text=alert_message),
+            call(channel="@bob", text=alert_message),
+            call(channel="#incident-room", text=alert_message),
+            call(channel="@joseph", text=alert_message),
+        ]
+        mock_slack_client.assert_has_calls(calls, any_order=True)
+
+    def test_handles_invalid_slack_alerts_and_skips_if_condition_is_false(
+        self,
+        mock_execution,
+        get_connection,
+        mock_slack_client,
+    ):
+        mock_execution.return_value = [(5,)]
+
+        loader = whale_loader.WhaleLoader()
+        loader.init(self.loader_config)
+        loader.load(self.record)
+
+        sql_query = f"select count(distinct id) from {self.schema}.{self.table} where id is null"
+        alert_message = f"Nulls found in {self.schema}.{self.table} column id."
+
+        slack_alerts = [
+            SlackAlert(
+                condition=">0",
+                message=alert_message,
+                channels=["#data-monitoring", "@bob"],
+            ),
+            SlackAlert(
+                condition="not a valid condition",
+                message=alert_message,
+                channels=["@jack"],
+            ),
+            SlackAlert(
+                condition=">2",
+                message=alert_message,
+                channels=[],
+            ),
+        ]
+
+        self.add_metrics_and_alerts_to_markdown("null-ids", sql_query, slack_alerts)
+
+        mock_slack_client.return_value = {"message": {"text": alert_message}}
+
+        extractor = MetricRunner()
+        extractor.init(self.extractor_config)
+
+        results = extractor.extract()
+
+        calls = [
+            call(channel="#data-monitoring", text=alert_message),
+            call(channel="@bob", text=alert_message),
+        ]
+        mock_slack_client.assert_has_calls(calls, any_order=True)
+
+    def add_metrics_and_alerts_to_markdown(
+        self,
+        metric_name,
+        sql_query,
+        slack_alerts: list = [],
+    ):
+        yaml_dict = {
+            metric_name: {
+                "sql": f" | {sql_query}",
+            }
+        }
+
+        if slack_alerts:
+            yaml_dict[metric_name]["alerts"] = [
+                {
+                    "condition": alert.condition,
+                    "message": alert.message,
+                    "slack": alert.channels,
+                }
+                for alert in slack_alerts
+            ]
+
+        with open(self.table_stub_path, "a") as f:
+            f.write(
+                f"""
+{DEFINED_METRICS_DELIMITER}
+{yaml.dump(yaml_dict, sort_keys=False)}"""
+            )

--- a/pipelines/tests/unit/utils/test_sql.py
+++ b/pipelines/tests/unit/utils/test_sql.py
@@ -33,13 +33,17 @@ class TestTemplateDirectory:
         write_template_to_file(mock_template_dir / INVALID_FILE_NAME, INVALID_TEMPLATE)
 
     @patch("builtins.print")
-    def test__validate_and_print_result_returns_correct_passing_result(self, mock_print, mock_template_dir):
+    def test__validate_and_print_result_returns_correct_passing_result(
+        self, mock_print, mock_template_dir
+    ):
         error = _validate_and_print_result(mock_template_dir / VALID_FILE_NAME)
         mock_print.assert_called_with("[\x1b[32m✓\x1b[0m] valid.sql")
         assert error is None
 
     @patch("builtins.print")
-    def test__validate_and_print_result_returns_correct_failing_result(self, mock_print, mock_template_dir):
+    def test__validate_and_print_result_returns_correct_failing_result(
+        self, mock_print, mock_template_dir
+    ):
         error = _validate_and_print_result(mock_template_dir / INVALID_FILE_NAME)
         mock_print.assert_has_calls([call("[\x1b[31mx\x1b[0m] invalid.sql")]),
         assert error is not None
@@ -57,6 +61,5 @@ class TestTemplateDirectory:
         templated_query = template_query(
             query,
             connection_name="valid",
-            )
+        )
         assert templated_query == "\n5"
-

--- a/pipelines/whale/models/metric_value.py
+++ b/pipelines/whale/models/metric_value.py
@@ -1,8 +1,13 @@
 import os
+import logging
 from pathlib import Path
+from slack_sdk import WebClient
+from slack_sdk.errors import SlackApiError
 
 from whale.utils import paths
 from whale.utils import get_table_file_path_relative
+
+LOGGER = logging.getLogger(__name__)
 
 
 class MetricValue(object):
@@ -46,3 +51,60 @@ class MetricValue(object):
         Path(record_dirname).mkdir(parents=True, exist_ok=True)
         with open(record_path, "a") as f:
             f.write(f"{self.value},{self.execution_time}\n")
+
+
+class SlackAlert(object):
+    """
+    Sending alerts to the SlackSDK
+    """
+
+    def __init__(
+        self,
+        condition: str,
+        message: str,
+        channels: str,
+    ):
+        self.condition = condition
+        self.message = message
+        self.channels = channels
+
+    def send_slack_alert(self, metric_value):
+        if self.condition is None:
+            return
+
+        if self.channels is None:
+            return
+
+        if self.message is None:
+            return
+
+        token = os.environ.get("WHALE_SLACK_TOKEN")
+        if not token:
+            LOGGER.warning("Could not find environment variable WHALE_SLACK_TOKEN.")
+            return
+
+        if not self.evaluate_condition(metric_value):
+            return
+
+        client = WebClient(token=token)
+
+        for channel in self.channels:
+            try:
+                # TODO: Think of a better Slack message than just the message indicated.
+                response = client.chat_postMessage(channel=channel, text=self.message)
+                assert response["message"]["text"] == self.message
+
+            except SlackApiError as e:
+                assert e.response["ok"] is False
+                assert e.response["error"]
+                LOGGER.warning(f"Got an error: {e.response['error']}")
+
+    def evaluate_condition(self, metric_value):
+        try:
+            return eval(f"{metric_value} {self.condition}")
+        except Exception as e:
+            LOGGER.warning(e)
+            LOGGER.warning(
+                f"Could not evaluate expression `value {self.condition}`, where value is {metric_value}."
+            )
+            return False


### PR DESCRIPTION
Closes https://github.com/dataframehq/whale/issues/80.

Some notes:
- [Slack suggests](https://github.com/slackapi/python-slack-sdk#sending-a-message-to-slack) using the Slack channel id instead of the Slack channel itself. I went through Whale's Slack instance, but failed to find the ID of a channel. Instead of digging further, I decided to allow channel names itself. If it's too difficult for me to find the channel ID, users will likely suffer from the same problem.
- In order to authorize the bot, a token needs to be provided. [Slack's documentation](https://github.com/slackapi/python-slack-sdk#sending-a-message-to-slack) stores this token as an environment variable. **My suggestion is to let users store this token as an environment variable first**. If this alert feature becomes more popular, we can think about adding it to the onboarding process and store it in a configuration file.
- In a next step we should update our documentation to onboard people to this feature 🚀 
