### PR TITLE
fix: broken deduplication.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,13 @@ python:
 	cp ${python_directory}/build_script.py ${dependency_binary_dir}
 	cp ${python_directory}/run_script.py ${dependency_binary_dir}
 
-.PHONY: install
-install: python
+.PHONY: rust
+install_rust:
 	mkdir -p ${install_dir}
 	cp ./cli/target/release/whale ${install_dir}
+
+.PHONY: install
+install: python rust
 
 .PHONY: test_python
 test_python:

--- a/cli/src/filesystem.rs
+++ b/cli/src/filesystem.rs
@@ -24,19 +24,12 @@ pub fn create_file_structure() {
     .collect()
 }
 
-fn remove_duplicate_lines_from(file_path: &str) -> BTreeSet<String> {
-    let path = Path::new(file_path);
-
-    let contents =
-        fs::read_to_string(path).unwrap_or_else(|_| panic!("Can't read file `{}`", file_path));
-
-    contents
-        .lines()
-        .map(|i| i.to_owned())
-        .collect::<BTreeSet<String>>()
-}
-
 pub fn deduplicate_file(file_path_string: &str) {
+    let file_path = Path::new(file_path_string);
+    let contents = fs::read_to_string(file_path)
+        .unwrap_or_else(|_| panic!("Can't read file `{}`", file_path_string));
+    let lines: BTreeSet<_> = contents.lines().collect();
+
     match OpenOptions::new()
         .create(true)
         .write(true)
@@ -45,7 +38,7 @@ pub fn deduplicate_file(file_path_string: &str) {
     {
         Ok(file) => {
             let mut writer = BufWriter::new(&file);
-            for line in remove_duplicate_lines_from(file_path_string) {
+            for line in lines {
                 writeln!(writer, "{}", line).unwrap();
             }
             writer


### PR DESCRIPTION
Two small changes:
* Small bug in rust code -- the recent refactor of the `deduplicate_file` function for some reason actually just deletes the manifest used by skim. @biomunky FYI. Sorry I missed this before merge.
* Split up makefile so `make && make rust` can be run to test rust without setting up python env.