### PR TITLE
Enable users to use own Slack workspace for Slack alerts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ install: python rust
 
 .PHONY: test_python
 test_python:
-	${python3_alias} -b -m pytest -o log_cli=true ${python_directory}/tests --cov=whale --cov-report=xml
+	${python3_alias} -b -m pytest -o log_cli=true ${python_directory}/tests services/tests --cov=whale --cov-report=xml
 	flake8 ${python_directory}/whale/ --exit-zero
 
 .PHONY: test

--- a/docs/features/metrics.md
+++ b/docs/features/metrics.md
@@ -97,11 +97,16 @@ A full list of all historical values are saved in `~/.whale/metrics`.
 
 
 ## Slack alerts
-{% hint style="warning" %}
-We are building out our dedicated 🐳 Slack app, but in the meantime, feel free to join [our community](https://join.slack.com/t/df-whale/shared_invite/zt-k4zmmzw2-mFuBJE1er4AEuW6PF9cpfw) and set up alerts there.
-{% endhint %}
 
 Metrics can be enhanced with Slack alerts. These will send a message to you or your channel if a certain condition is met.
+
+### Setup
+To enable Slack alerts for your Slack workspace first add the 🐳 Slack app:
+<a href="https://slack.com/oauth/v2/authorize?client_id=1407551924673.1505585912487&scope=chat:write,im:write&user_scope="><img alt="Add to Slack" height="40" width="139" src="https://platform.slack-edge.com/img/add_to_slack.png" srcSet="https://platform.slack-edge.com/img/add_to_slack.png 1x, https://platform.slack-edge.com/img/add_to_slack@2x.png 2x" /></a>
+
+Once you hit "Allow", you will be redirected back here. This time, however, an access token will be added to the URL parameters like so: https://docs.whale.cx/features/metrics#setup?token=123. Store this token, 123 in the URL given before, as an environment variable called `WHALE_SLACK_TOKEN`. That's all!
+
+### Syntax
 The syntax is as follows:
 
 ```text

--- a/pipelines/dev-requirements.txt
+++ b/pipelines/dev-requirements.txt
@@ -2,6 +2,7 @@ attrs==20.2.0
 black==20.8b1
 coverage==5.3
 flake8==3.8.4
+Flask==1.1.2
 iniconfig==1.1.1
 mccabe==0.6.1
 mock==4.0.2

--- a/services/slack_access_token.py
+++ b/services/slack_access_token.py
@@ -1,0 +1,30 @@
+from urllib import parse
+import requests
+from flask import Flask, request, redirect, flash
+
+app = Flask(__name__)
+
+SLACK_API_URL = "https://slack.com/api/oauth.v2.access"
+REDIRECT_URL = "https://docs.whale.cx/features/metrics#setup"
+
+CLIENT_ID = "123"
+CLIENT_SECRET = "456"
+
+@app.route('/', methods=['GET'])
+def code_to_token():
+    code_param = request.args.get("code")
+
+    r = requests.get(
+        SLACK_API_URL,
+        params={
+            "code": code_param,
+            "client_id": CLIENT_ID,
+            "client_secret": CLIENT_SECRET,
+        },
+    )
+
+    if not r.json()['ok']:
+        return redirect(f"{REDIRECT_URL}?error={r.json().get('error')}")
+
+    return redirect(f"{REDIRECT_URL}?token={r.json().get('access_token')}")
+

--- a/services/tests/test_slack_access_token.py
+++ b/services/tests/test_slack_access_token.py
@@ -1,0 +1,35 @@
+import pytest
+from flask import request
+from unittest.mock import Mock, patch
+
+from services.slack_access_token import app
+
+WHALE_DOCS_PATCH = "/slack-api-path" # Flask cannot test external redirects
+
+@pytest.fixture
+def client():
+    app.config["TESTING"] = True
+    with app.test_client() as client:
+        yield client
+
+@patch('requests.get')
+@patch('services.slack_access_token.REDIRECT_URL', WHALE_DOCS_PATCH)
+def test_passes_access_token(mock_get, client):
+    token = "000"
+    mock_get.return_value = Mock(ok=True)
+    mock_get.return_value.json.return_value = {"ok": True, "app_id": "ABC", "access_token": token}
+
+    response = client.get("/?code=123", follow_redirects=True)
+
+    assert request.full_path == f"{WHALE_DOCS_PATCH}?token={token}"
+
+@patch('requests.get')
+@patch('services.slack_access_token.REDIRECT_URL', WHALE_DOCS_PATCH)
+def test_passes_on_error(mock_get, client):
+    error_message = "invalid_code"
+    mock_get.return_value = Mock(ok=False)
+    mock_get.return_value.json.return_value = {"ok": False, "error": error_message}
+
+    rv = client.get("/?code=123", follow_redirects=True)
+
+    assert request.full_path == f"{WHALE_DOCS_PATCH}?error={error_message}"


### PR DESCRIPTION
Currently Slack alerts can only be sent to Whale's own Slack workspace. This PR enables users to send Slack alerts to their own workspace.

Some design choices:
- Instead of designing my own front-end, where I display the access token, I just redirect back to our documentation and explain that the token is passed via an URL parameter. Is there a better solution?
- Once merged and deployed we should test the flow and the design of the docs, since I can't see that myself.

Left to do:
- Have some deployment where we call `python3 -m flask run`. 
- Find a way to store `CLIENT_ID` and `CLIENT_SECRET`. That depends a bit on the target infrastructure, so I just put dummy data.