### PR TITLE
Fix snowflake onboarding process

### DIFF
--- a/cli/src/warehouse/mod.rs
+++ b/cli/src/warehouse/mod.rs
@@ -7,4 +7,5 @@ pub mod gitserver;
 pub mod glue;
 pub mod hive;
 pub mod metadatasource;
+pub mod snowflake;
 pub mod whutils;

--- a/cli/src/warehouse/snowflake.rs
+++ b/cli/src/warehouse/snowflake.rs
@@ -1,0 +1,57 @@
+use super::{metadatasource::MetadataSource, whutils::get_name};
+use crate::serialization::{Deserialize, Serialize, YamlWriter};
+use crate::utils;
+
+#[derive(Serialize, Deserialize)]
+pub struct Snowflake {
+    name: String,
+    metadata_source: MetadataSource,
+    account: String,
+    username: String,
+    password: String,
+    database: String,
+}
+
+impl Snowflake {
+    pub fn prompt_add_details() {
+
+        // name
+        let name: String = get_name();
+
+        // account
+        let account_msg = "What is the account for this warehouse (if your snowflake URL is robert123.snowflakecomputing.com, robert123 is your account)?";
+        let account: String = utils::get_input_with_message(account_msg);
+
+        // username
+        let username_msg = "Username?";
+        let username: String = utils::get_input_with_message(username_msg);
+
+        // password
+        let password_msg = "Password?";
+        let password: String = utils::get_input_with_message(password_msg);
+
+        // database
+        let database_msg = {
+            "Database? (In ANSI standard, this is the 'catalog', but Snowflake calls it a 'database'.)"
+        };
+        let database: String = utils::get_input_with_message(database_msg);
+
+        let compiled_config = Snowflake {
+            name,
+            metadata_source: MetadataSource::Snowflake,
+            account,
+            username,
+            password,
+            database,
+        };
+
+        compiled_config
+            .register_connection()
+            .expect("Failed to register warehouse configuration");
+
+        println!(
+            "Added warehouse: {:?} to ~/.whale/config/connections.yaml.",
+            compiled_config.name
+        );
+    }
+}

--- a/cli/src/warehouse/snowflake.rs
+++ b/cli/src/warehouse/snowflake.rs
@@ -14,7 +14,6 @@ pub struct Snowflake {
 
 impl Snowflake {
     pub fn prompt_add_details() {
-
         // name
         let name: String = get_name();
 

--- a/cli/src/warehouse/whutils.rs
+++ b/cli/src/warehouse/whutils.rs
@@ -6,8 +6,9 @@ use std::str::FromStr;
 use super::{
     bigquery::Bigquery, buildscript::BuildScript, errors::ParseMetadataSourceError,
     generic::GenericWarehouse, gitserver::GitServer, glue::Glue, hive::HiveMetastore,
-    metadatasource::MetadataSource,
+    metadatasource::MetadataSource
 };
+use crate::warehouse::snowflake::Snowflake;
 use crate::utils;
 
 pub fn prompt_add_warehouse(is_first_time: bool) {
@@ -58,12 +59,12 @@ pub fn prompt_add_warehouse(is_first_time: bool) {
         | Ok(MetadataSource::Postgres)
         | Ok(MetadataSource::Presto)
         | Ok(MetadataSource::Redshift)
-        | Ok(MetadataSource::Snowflake)
         | Ok(MetadataSource::AmundsenNeo4j) => {
             GenericWarehouse::prompt_add_details(warehouse_enum.unwrap())
         }
         Ok(MetadataSource::Glue) => Glue::prompt_add_details(),
         Ok(MetadataSource::HiveMetastore) => HiveMetastore::prompt_add_details(),
+        Ok(MetadataSource::Snowflake) => Snowflake::prompt_add_details(),
         Ok(MetadataSource::GitServer) => GitServer::prompt_add_details(),
         Ok(MetadataSource::BuildScript) => BuildScript::prompt_add_details(),
         Err(e) => handle_error(e),

--- a/cli/src/warehouse/whutils.rs
+++ b/cli/src/warehouse/whutils.rs
@@ -6,9 +6,8 @@ use std::str::FromStr;
 use super::{
     bigquery::Bigquery, buildscript::BuildScript, errors::ParseMetadataSourceError,
     generic::GenericWarehouse, gitserver::GitServer, glue::Glue, hive::HiveMetastore,
-    metadatasource::MetadataSource
+    metadatasource::MetadataSource, snowflake::Snowflake,
 };
-use crate::warehouse::snowflake::Snowflake;
 use crate::utils;
 
 pub fn prompt_add_warehouse(is_first_time: bool) {

--- a/pipelines/setup.py
+++ b/pipelines/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, "README.md"), encoding="utf-8") as f:
 
 setuptools.setup(
     name="whale-pipelines",
-    version="1.3.2",
+    version="1.3.3",
     author="Robert Yi",
     author_email="robert@ryi.me",
     description="A pared-down metadata scraper + SQL runner.",

--- a/pipelines/tests/unit/utils/test_extractor_wrappers.py
+++ b/pipelines/tests/unit/utils/test_extractor_wrappers.py
@@ -47,7 +47,7 @@ TEST_BIGQUERY_CONNECTION_CONFIG = ConnectionConfigSchema(
 
 TEST_GLUE_CONNECTION_CONFIG = ConnectionConfigSchema(
     metadata_source="glue",
-    filters="mock_filter",
+    filter_key="mock_filter",
 )
 
 TEST_NEO4J_CONNECTION_CONFIG = ConnectionConfigSchema(

--- a/pipelines/whale/models/connection_config.py
+++ b/pipelines/whale/models/connection_config.py
@@ -11,6 +11,7 @@ class ConnectionConfigSchema(object):
         username: Optional[str] = None,
         password: Optional[str] = None,
         name: Optional[str] = None,
+        account: Optional[str] = None,  # Snowflake-specific
         database: Optional[str] = None,
         instance: Optional[str] = None,
         cluster: Optional[str] = None,
@@ -31,7 +32,6 @@ class ConnectionConfigSchema(object):
         page_size: Optional[str] = None,
         filter_key: Optional[str] = None,
         where_clause_suffix: Optional[str] = "",
-        **kwargs,
     ):
 
         self.uri = uri
@@ -43,6 +43,7 @@ class ConnectionConfigSchema(object):
         self.username = username
         self.password = password
         self.name = name
+        self.account = account
         self.database = database
         self.instance = instance
         self.cluster = cluster
@@ -50,7 +51,7 @@ class ConnectionConfigSchema(object):
         self.included_schemas = included_schemas
         self.excluded_schemas = excluded_schemas
         self.included_keys = included_keys
-        self.excluded_keys = included_keys
+        self.excluded_keys = excluded_keys
         self.included_key_regex = included_key_regex
         self.excluded_key_regex = excluded_key_regex
         self.included_tables_regex = included_tables_regex

--- a/pipelines/whale/models/connection_config.py
+++ b/pipelines/whale/models/connection_config.py
@@ -87,7 +87,10 @@ class ConnectionConfigSchema(object):
                 self.dialect = self.metadata_source
 
             if self.metadata_source == "snowflake":
-                uri = self.account
+                if self.account is not None:
+                    uri = self.account
+                else:
+                    uri = self.uri
             else:
                 uri = self.uri
 

--- a/pipelines/whale/models/connection_config.py
+++ b/pipelines/whale/models/connection_config.py
@@ -85,7 +85,12 @@ class ConnectionConfigSchema(object):
                 self.dialect = self.dialect
             else:
                 self.dialect = self.metadata_source
-            uri = self.uri
+
+            if self.metadata_source == "snowflake":
+                uri = self.account
+            else:
+                uri = self.uri
+
             port_placeholder = f":{self.port}" if self.port is not None else ""
             database = self.database or ""
 

--- a/pipelines/whale/models/connection_config.py
+++ b/pipelines/whale/models/connection_config.py
@@ -85,9 +85,9 @@ class ConnectionConfigSchema(object):
             else:
                 self.dialect = self.metadata_source
             uri = self.uri
-            port = self.port
+            port_placeholder = f":{self.port}" if self.port is not None else ""
             database = self.database or ""
 
-            conn_string = f"{self.dialect}://{username_password_placeholder}@{uri}:{port}/{database}"
+            conn_string = f"{self.dialect}://{username_password_placeholder}@{uri}{port_placeholder}/{database}"
 
         self.conn_string = conn_string

--- a/pipelines/whale/utils/extractor_wrappers.py
+++ b/pipelines/whale/utils/extractor_wrappers.py
@@ -241,7 +241,7 @@ def configure_snowflake_extractors(connection: ConnectionConfigSchema):
         {
             conn_string_key: connection.conn_string,
             f"{scope}.{Extractor.DATABASE_KEY}": connection.name,
-            f"{scope}.{Extractor.CLUSTER_KEY}": connection.cluster,
+            f"{scope}.{Extractor.CLUSTER_KEY}": connection.database,
             f"{scope}.{Extractor.WHERE_CLAUSE_SUFFIX_KEY}": connection.where_clause_suffix,
         }
     )


### PR DESCRIPTION
Snowflake onboarding was only semi-functional before this -- the onboarding process was broken (and requested an unnecessary port object), though the connection and scraping worked. This change backwards-compatibly fixes the onboarding process and proper configuration of the extractor using the snowflake jargon.