### PR TITLE
chore: stop making each tag a prerelease by default

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -53,7 +53,7 @@ jobs:
         tag_name: ${{ github.ref }}
         release_name: ${{ github.ref }}
         draft: false
-        prerelease: true
+        prerelease: false
 
     - name: Upload Release Asset
       uses: actions/upload-release-asset@v1


### PR DESCRIPTION
Have been meaning to fix this for months now -- I've just been manually making the prereleases full releases out of laziness. Modifying this so people don't end up getting emails about "pre-releases" when they are actually releases. 