### PR TITLE
Refactor table metadata file & other small refactors

### DIFF
--- a/pipelines/tests/unit/engine/test_presto_engine.py
+++ b/pipelines/tests/unit/engine/test_presto_engine.py
@@ -6,7 +6,8 @@ from pyhocon import ConfigFactory
 
 from whale.engine.presto_engine import PrestoEngine
 from whale.engine.sql_alchemy_engine import SQLAlchemyEngine
-from whale.models.table_metadata import ColumnMetadata, TableMetadata
+from whale.models.column_metadata import ColumnMetadata
+from whale.models.table_metadata import TableMetadata
 
 MOCK_CONNECTION_NAME = "TEST_CONNECTION"
 MOCK_DATABASE_NAME = "mock_database"
@@ -24,7 +25,7 @@ MOCK_INFORMATION_SCHEMA_RESULT_1 = {
     "col_sort_order": 0,
     "is_partition_col": 0,
     "col_description": "unique id",
-    "col_type": "varchar(64)",
+    "data_type": "varchar(64)",
     "is_view": "0",
 }
 MOCK_INFORMATION_SCHEMA_RESULT_2 = {
@@ -36,7 +37,7 @@ MOCK_INFORMATION_SCHEMA_RESULT_2 = {
     "col_sort_order": "1",
     "is_partition_col": "1",
     "col_description": "datestamp",
-    "col_type": "varchar(64)",
+    "data_type": "varchar(64)",
     "is_view": "0",
 }
 
@@ -79,7 +80,7 @@ class TestPrestoEngine(unittest.TestCase):
                 description=MOCK_INFORMATION_SCHEMA_RESULT_1[
                     "col_description"
                 ],  # noqa: 501
-                col_type=MOCK_INFORMATION_SCHEMA_RESULT_1["col_type"],
+                data_type=MOCK_INFORMATION_SCHEMA_RESULT_1["data_type"],
                 sort_order=MOCK_INFORMATION_SCHEMA_RESULT_1["col_sort_order"],
                 is_partition_column=None,
             ),
@@ -88,7 +89,7 @@ class TestPrestoEngine(unittest.TestCase):
                 description=MOCK_INFORMATION_SCHEMA_RESULT_2[
                     "col_description"
                 ],  # noqa: 501
-                col_type=MOCK_INFORMATION_SCHEMA_RESULT_2["col_type"],
+                data_type=MOCK_INFORMATION_SCHEMA_RESULT_2["data_type"],
                 sort_order=MOCK_INFORMATION_SCHEMA_RESULT_2["col_sort_order"],
                 is_partition_column=None,
             ),

--- a/pipelines/tests/unit/extractor/test_glue_extractor.py
+++ b/pipelines/tests/unit/extractor/test_glue_extractor.py
@@ -5,7 +5,8 @@ from mock import patch
 from pyhocon import ConfigFactory
 
 from whale.extractor.glue_extractor import GlueExtractor
-from whale.models.table_metadata import TableMetadata, ColumnMetadata
+from whale.models.table_metadata import TableMetadata
+from whale.models.column_metadata import ColumnMetadata
 
 
 @patch("whale.extractor.glue_extractor.boto3.client", lambda x: None)

--- a/pipelines/tests/unit/extractor/test_postgres_metadata_extractor.py
+++ b/pipelines/tests/unit/extractor/test_postgres_metadata_extractor.py
@@ -16,10 +16,10 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
-            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
-            PostgresMetadataExtractor.CLUSTER_KEY: 'MY_CLUSTER',
+            f"extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}": "TEST_CONNECTION",
+            PostgresMetadataExtractor.CLUSTER_KEY: "MY_CLUSTER",
             PostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False,
-            PostgresMetadataExtractor.DATABASE_KEY: 'postgres'
+            PostgresMetadataExtractor.DATABASE_KEY: "postgres",
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -27,7 +27,7 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
         """
         Test Extraction with empty result from query
         """
-        with patch.object(SQLAlchemyExtractor, '_get_connection'):
+        with patch.object(SQLAlchemyExtractor, "_get_connection"):
             extractor = PostgresMetadataExtractor()
             extractor.init(self.conf)
 
@@ -35,184 +35,289 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
             self.assertEqual(results, None)
 
     def test_extraction_with_single_result(self) -> None:
-        with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
+        with patch.object(SQLAlchemyExtractor, "_get_connection") as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
             sql_execute = MagicMock()
             connection.execute = sql_execute
-            table = {'schema': 'test_schema',
-                     'name': 'test_table',
-                     'description': 'a table for testing',
-                     'is_view': 0,
-                     'cluster':
-                         self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
-                     }
+            table = {
+                "schema": "test_schema",
+                "name": "test_table",
+                "description": "a table for testing",
+                "is_view": 0,
+                "cluster": self.conf[PostgresMetadataExtractor.CLUSTER_KEY],
+            }
 
             sql_execute.return_value = [
                 self._union(
-                    {'col_name': 'col_id1',
-                     'data_type': 'bigint',
-                     'col_description': 'description of id1',
-                     'col_sort_order': 0}, table),
+                    {
+                        "col_name": "col_id1",
+                        "data_type": "bigint",
+                        "col_description": "description of id1",
+                        "col_sort_order": 0,
+                    },
+                    table,
+                ),
                 self._union(
-                    {'col_name': 'col_id2',
-                     'data_type': 'bigint',
-                     'col_description': 'description of id2',
-                     'col_sort_order': 1}, table),
+                    {
+                        "col_name": "col_id2",
+                        "data_type": "bigint",
+                        "col_description": "description of id2",
+                        "col_sort_order": 1,
+                    },
+                    table,
+                ),
                 self._union(
-                    {'col_name': 'is_active',
-                     'data_type': 'boolean',
-                     'col_description': None,
-                     'col_sort_order': 2}, table),
+                    {
+                        "col_name": "is_active",
+                        "data_type": "boolean",
+                        "col_description": None,
+                        "col_sort_order": 2,
+                    },
+                    table,
+                ),
                 self._union(
-                    {'col_name': 'source',
-                     'data_type': 'varchar',
-                     'col_description': 'description of source',
-                     'col_sort_order': 3}, table),
+                    {
+                        "col_name": "source",
+                        "data_type": "varchar",
+                        "col_description": "description of source",
+                        "col_sort_order": 3,
+                    },
+                    table,
+                ),
                 self._union(
-                    {'col_name': 'etl_created_at',
-                     'data_type': 'timestamp',
-                     'col_description': 'description of etl_created_at',
-                     'col_sort_order': 4}, table),
+                    {
+                        "col_name": "etl_created_at",
+                        "data_type": "timestamp",
+                        "col_description": "description of etl_created_at",
+                        "col_sort_order": 4,
+                    },
+                    table,
+                ),
                 self._union(
-                    {'col_name': 'ds',
-                     'data_type': 'varchar',
-                     'col_description': None,
-                     'col_sort_order': 5}, table)
+                    {
+                        "col_name": "ds",
+                        "data_type": "varchar",
+                        "col_description": None,
+                        "col_sort_order": 5,
+                    },
+                    table,
+                ),
             ]
 
             extractor = PostgresMetadataExtractor()
             extractor.init(self.conf)
             actual = extractor.extract()
-            expected = TableMetadata('postgres', 'MY_CLUSTER', 'test_schema', 'test_table', 'a table for testing',
-                                     [ColumnMetadata('col_id1', 'description of id1', 'bigint', 0),
-                                      ColumnMetadata('col_id2', 'description of id2', 'bigint', 1),
-                                      ColumnMetadata('is_active', None, 'boolean', 2),
-                                      ColumnMetadata('source', 'description of source', 'varchar', 3),
-                                      ColumnMetadata('etl_created_at', 'description of etl_created_at', 'timestamp', 4),
-                                      ColumnMetadata('ds', None, 'varchar', 5)], 0)
+            expected = TableMetadata(
+                "postgres",
+                "MY_CLUSTER",
+                "test_schema",
+                "test_table",
+                "a table for testing",
+                [
+                    ColumnMetadata("col_id1", "description of id1", "bigint", 0),
+                    ColumnMetadata("col_id2", "description of id2", "bigint", 1),
+                    ColumnMetadata("is_active", None, "boolean", 2),
+                    ColumnMetadata("source", "description of source", "varchar", 3),
+                    ColumnMetadata(
+                        "etl_created_at",
+                        "description of etl_created_at",
+                        "timestamp",
+                        4,
+                    ),
+                    ColumnMetadata("ds", None, "varchar", 5),
+                ],
+                0,
+            )
 
             self.assertEqual(expected.__repr__(), actual.__repr__())
             self.assertIsNone(extractor.extract())
 
     def test_extraction_with_multiple_result(self) -> None:
-        with patch.object(SQLAlchemyExtractor, '_get_connection') as mock_connection:
+        with patch.object(SQLAlchemyExtractor, "_get_connection") as mock_connection:
             connection = MagicMock()
             mock_connection.return_value = connection
             sql_execute = MagicMock()
             connection.execute = sql_execute
-            table = {'schema': 'test_schema1',
-                     'name': 'test_table1',
-                     'description': 'test table 1',
-                     'is_view': 0,
-                     'cluster':
-                         self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
-                     }
+            table = {
+                "schema": "test_schema1",
+                "name": "test_table1",
+                "description": "test table 1",
+                "is_view": 0,
+                "cluster": self.conf[PostgresMetadataExtractor.CLUSTER_KEY],
+            }
 
-            table1 = {'schema': 'test_schema1',
-                      'name': 'test_table2',
-                      'description': 'test table 2',
-                      'is_view': 0,
-                      'cluster':
-                          self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
-                      }
+            table1 = {
+                "schema": "test_schema1",
+                "name": "test_table2",
+                "description": "test table 2",
+                "is_view": 0,
+                "cluster": self.conf[PostgresMetadataExtractor.CLUSTER_KEY],
+            }
 
-            table2 = {'schema': 'test_schema2',
-                      'name': 'test_table3',
-                      'description': 'test table 3',
-                      'is_view': 0,
-                      'cluster':
-                          self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
-                      }
+            table2 = {
+                "schema": "test_schema2",
+                "name": "test_table3",
+                "description": "test table 3",
+                "is_view": 0,
+                "cluster": self.conf[PostgresMetadataExtractor.CLUSTER_KEY],
+            }
 
             sql_execute.return_value = [
                 self._union(
-                    {'col_name': 'col_id1',
-                     'data_type': 'bigint',
-                     'col_description': 'description of col_id1',
-                     'col_sort_order': 0}, table),
+                    {
+                        "col_name": "col_id1",
+                        "data_type": "bigint",
+                        "col_description": "description of col_id1",
+                        "col_sort_order": 0,
+                    },
+                    table,
+                ),
                 self._union(
-                    {'col_name': 'col_id2',
-                     'data_type': 'bigint',
-                     'col_description': 'description of col_id2',
-                     'col_sort_order': 1}, table),
+                    {
+                        "col_name": "col_id2",
+                        "data_type": "bigint",
+                        "col_description": "description of col_id2",
+                        "col_sort_order": 1,
+                    },
+                    table,
+                ),
                 self._union(
-                    {'col_name': 'is_active',
-                     'data_type': 'boolean',
-                     'col_description': None,
-                     'col_sort_order': 2}, table),
+                    {
+                        "col_name": "is_active",
+                        "data_type": "boolean",
+                        "col_description": None,
+                        "col_sort_order": 2,
+                    },
+                    table,
+                ),
                 self._union(
-                    {'col_name': 'source',
-                     'data_type': 'varchar',
-                     'col_description': 'description of source',
-                     'col_sort_order': 3}, table),
+                    {
+                        "col_name": "source",
+                        "data_type": "varchar",
+                        "col_description": "description of source",
+                        "col_sort_order": 3,
+                    },
+                    table,
+                ),
                 self._union(
-                    {'col_name': 'etl_created_at',
-                     'data_type': 'timestamp',
-                     'col_description': 'description of etl_created_at',
-                     'col_sort_order': 4}, table),
+                    {
+                        "col_name": "etl_created_at",
+                        "data_type": "timestamp",
+                        "col_description": "description of etl_created_at",
+                        "col_sort_order": 4,
+                    },
+                    table,
+                ),
                 self._union(
-                    {'col_name': 'ds',
-                     'data_type': 'varchar',
-                     'col_description': None,
-                     'col_sort_order': 5}, table),
+                    {
+                        "col_name": "ds",
+                        "data_type": "varchar",
+                        "col_description": None,
+                        "col_sort_order": 5,
+                    },
+                    table,
+                ),
                 self._union(
-                    {'col_name': 'col_name',
-                     'data_type': 'varchar',
-                     'col_description': 'description of col_name',
-                     'col_sort_order': 0}, table1),
+                    {
+                        "col_name": "col_name",
+                        "data_type": "varchar",
+                        "col_description": "description of col_name",
+                        "col_sort_order": 0,
+                    },
+                    table1,
+                ),
                 self._union(
-                    {'col_name': 'col_name2',
-                     'data_type': 'varchar',
-                     'col_description': 'description of col_name2',
-                     'col_sort_order': 1}, table1),
+                    {
+                        "col_name": "col_name2",
+                        "data_type": "varchar",
+                        "col_description": "description of col_name2",
+                        "col_sort_order": 1,
+                    },
+                    table1,
+                ),
                 self._union(
-                    {'col_name': 'col_id3',
-                     'data_type': 'varchar',
-                     'col_description': 'description of col_id3',
-                     'col_sort_order': 0}, table2),
+                    {
+                        "col_name": "col_id3",
+                        "data_type": "varchar",
+                        "col_description": "description of col_id3",
+                        "col_sort_order": 0,
+                    },
+                    table2,
+                ),
                 self._union(
-                    {'col_name': 'col_name3',
-                     'data_type': 'varchar',
-                     'col_description': 'description of col_name3',
-                     'col_sort_order': 1}, table2)
+                    {
+                        "col_name": "col_name3",
+                        "data_type": "varchar",
+                        "col_description": "description of col_name3",
+                        "col_sort_order": 1,
+                    },
+                    table2,
+                ),
             ]
 
             extractor = PostgresMetadataExtractor()
             extractor.init(self.conf)
 
-            expected = TableMetadata('postgres',
-                                     self.conf[PostgresMetadataExtractor.CLUSTER_KEY],
-                                     'test_schema1', 'test_table1', 'test table 1',
-                                     [ColumnMetadata('col_id1', 'description of col_id1', 'bigint', 0),
-                                      ColumnMetadata('col_id2', 'description of col_id2', 'bigint', 1),
-                                      ColumnMetadata('is_active', None, 'boolean', 2),
-                                      ColumnMetadata('source', 'description of source', 'varchar', 3),
-                                      ColumnMetadata('etl_created_at', 'description of etl_created_at', 'timestamp', 4),
-                                      ColumnMetadata('ds', None, 'varchar', 5)], 0)
+            expected = TableMetadata(
+                "postgres",
+                self.conf[PostgresMetadataExtractor.CLUSTER_KEY],
+                "test_schema1",
+                "test_table1",
+                "test table 1",
+                [
+                    ColumnMetadata("col_id1", "description of col_id1", "bigint", 0),
+                    ColumnMetadata("col_id2", "description of col_id2", "bigint", 1),
+                    ColumnMetadata("is_active", None, "boolean", 2),
+                    ColumnMetadata("source", "description of source", "varchar", 3),
+                    ColumnMetadata(
+                        "etl_created_at",
+                        "description of etl_created_at",
+                        "timestamp",
+                        4,
+                    ),
+                    ColumnMetadata("ds", None, "varchar", 5),
+                ],
+                0,
+            )
             self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
 
-            expected = TableMetadata('postgres',
-                                     self.conf[PostgresMetadataExtractor.CLUSTER_KEY],
-                                     'test_schema1', 'test_table2', 'test table 2',
-                                     [ColumnMetadata('col_name', 'description of col_name', 'varchar', 0),
-                                      ColumnMetadata('col_name2', 'description of col_name2', 'varchar', 1)], 0)
+            expected = TableMetadata(
+                "postgres",
+                self.conf[PostgresMetadataExtractor.CLUSTER_KEY],
+                "test_schema1",
+                "test_table2",
+                "test table 2",
+                [
+                    ColumnMetadata("col_name", "description of col_name", "varchar", 0),
+                    ColumnMetadata(
+                        "col_name2", "description of col_name2", "varchar", 1
+                    ),
+                ],
+                0,
+            )
             self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
 
-            expected = TableMetadata('postgres',
-                                     self.conf[PostgresMetadataExtractor.CLUSTER_KEY],
-                                     'test_schema2', 'test_table3', 'test table 3',
-                                     [ColumnMetadata('col_id3', 'description of col_id3', 'varchar', 0),
-                                      ColumnMetadata('col_name3', 'description of col_name3',
-                                                     'varchar', 1)], 0)
+            expected = TableMetadata(
+                "postgres",
+                self.conf[PostgresMetadataExtractor.CLUSTER_KEY],
+                "test_schema2",
+                "test_table3",
+                "test table 3",
+                [
+                    ColumnMetadata("col_id3", "description of col_id3", "varchar", 0),
+                    ColumnMetadata(
+                        "col_name3", "description of col_name3", "varchar", 1
+                    ),
+                ],
+                0,
+            )
             self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
 
             self.assertIsNone(extractor.extract())
             self.assertIsNone(extractor.extract())
 
-    def _union(self,
-               target: Dict[Any, Any],
-               extra: Dict[Any, Any]) -> Dict[Any, Any]:
+    def _union(self, target: Dict[Any, Any], extra: Dict[Any, Any]) -> Dict[Any, Any]:
         target.update(extra)
         return target
 
@@ -226,7 +331,7 @@ class TestPostgresMetadataExtractorWithWhereClause(unittest.TestCase):
 
         config_dict = {
             PostgresMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY: self.where_clause_suffix,
-            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION'
+            f"extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}": "TEST_CONNECTION",
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -234,7 +339,7 @@ class TestPostgresMetadataExtractorWithWhereClause(unittest.TestCase):
         """
         Test Extraction with empty result from query
         """
-        with patch.object(SQLAlchemyExtractor, '_get_connection'):
+        with patch.object(SQLAlchemyExtractor, "_get_connection"):
             extractor = PostgresMetadataExtractor()
             extractor.init(self.conf)
             self.assertTrue(self.where_clause_suffix in extractor.sql_stmt)
@@ -248,8 +353,8 @@ class TestPostgresMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
 
         config_dict = {
             PostgresMetadataExtractor.CLUSTER_KEY: self.cluster_key,
-            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
-            PostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False
+            f"extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}": "TEST_CONNECTION",
+            PostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False,
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -257,7 +362,7 @@ class TestPostgresMetadataExtractorClusterKeyNoTableCatalog(unittest.TestCase):
         """
         Test Extraction with empty result from query
         """
-        with patch.object(SQLAlchemyExtractor, '_get_connection'):
+        with patch.object(SQLAlchemyExtractor, "_get_connection"):
             extractor = PostgresMetadataExtractor()
             extractor.init(self.conf)
             self.assertTrue(self.cluster_key in extractor.sql_stmt)
@@ -269,8 +374,8 @@ class TestPostgresMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase)
         logging.basicConfig(level=logging.INFO)
 
         config_dict = {
-            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
-            PostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False
+            f"extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}": "TEST_CONNECTION",
+            PostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: False,
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -278,10 +383,12 @@ class TestPostgresMetadataExtractorNoClusterKeyNoTableCatalog(unittest.TestCase)
         """
         Test Extraction with empty result from query
         """
-        with patch.object(SQLAlchemyExtractor, '_get_connection'):
+        with patch.object(SQLAlchemyExtractor, "_get_connection"):
             extractor = PostgresMetadataExtractor()
             extractor.init(self.conf)
-            self.assertTrue(PostgresMetadataExtractor.DEFAULT_CLUSTER_NAME in extractor.sql_stmt)
+            self.assertTrue(
+                PostgresMetadataExtractor.DEFAULT_CLUSTER_NAME in extractor.sql_stmt
+            )
 
 
 class TestPostgresMetadataExtractorTableCatalogEnabled(unittest.TestCase):
@@ -292,8 +399,8 @@ class TestPostgresMetadataExtractorTableCatalogEnabled(unittest.TestCase):
 
         config_dict = {
             PostgresMetadataExtractor.CLUSTER_KEY: self.cluster_key,
-            f'extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}': 'TEST_CONNECTION',
-            PostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: True
+            f"extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}": "TEST_CONNECTION",
+            PostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME: True,
         }
         self.conf = ConfigFactory.from_dict(config_dict)
 
@@ -301,13 +408,12 @@ class TestPostgresMetadataExtractorTableCatalogEnabled(unittest.TestCase):
         """
         Test Extraction with empty result from query
         """
-        with patch.object(SQLAlchemyExtractor, '_get_connection'):
+        with patch.object(SQLAlchemyExtractor, "_get_connection"):
             extractor = PostgresMetadataExtractor()
             extractor.init(self.conf)
-            self.assertTrue('table_catalog' in extractor.sql_stmt)
+            self.assertTrue("table_catalog" in extractor.sql_stmt)
             self.assertFalse(self.cluster_key in extractor.sql_stmt)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()
-

--- a/pipelines/tests/unit/extractor/test_postgres_metadata_extractor.py
+++ b/pipelines/tests/unit/extractor/test_postgres_metadata_extractor.py
@@ -5,9 +5,10 @@ from typing import Any, Dict
 from mock import MagicMock, patch
 from pyhocon import ConfigFactory
 
-from databuilder.extractor.postgres_metadata_extractor import PostgresMetadataExtractor
+from whale.extractor.postgres_metadata_extractor import PostgresMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import ColumnMetadata, TableMetadata
+from whale.models.table_metadata import TableMetadata
+from whale.models.column_metadata import ColumnMetadata
 
 
 class TestPostgresMetadataExtractor(unittest.TestCase):
@@ -42,6 +43,7 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
             table = {'schema': 'test_schema',
                      'name': 'test_table',
                      'description': 'a table for testing',
+                     'is_view': 0,
                      'cluster':
                          self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
                      }
@@ -49,32 +51,32 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
             sql_execute.return_value = [
                 self._union(
                     {'col_name': 'col_id1',
-                     'col_type': 'bigint',
+                     'data_type': 'bigint',
                      'col_description': 'description of id1',
                      'col_sort_order': 0}, table),
                 self._union(
                     {'col_name': 'col_id2',
-                     'col_type': 'bigint',
+                     'data_type': 'bigint',
                      'col_description': 'description of id2',
                      'col_sort_order': 1}, table),
                 self._union(
                     {'col_name': 'is_active',
-                     'col_type': 'boolean',
+                     'data_type': 'boolean',
                      'col_description': None,
                      'col_sort_order': 2}, table),
                 self._union(
                     {'col_name': 'source',
-                     'col_type': 'varchar',
+                     'data_type': 'varchar',
                      'col_description': 'description of source',
                      'col_sort_order': 3}, table),
                 self._union(
                     {'col_name': 'etl_created_at',
-                     'col_type': 'timestamp',
+                     'data_type': 'timestamp',
                      'col_description': 'description of etl_created_at',
                      'col_sort_order': 4}, table),
                 self._union(
                     {'col_name': 'ds',
-                     'col_type': 'varchar',
+                     'data_type': 'varchar',
                      'col_description': None,
                      'col_sort_order': 5}, table)
             ]
@@ -88,7 +90,7 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
                                       ColumnMetadata('is_active', None, 'boolean', 2),
                                       ColumnMetadata('source', 'description of source', 'varchar', 3),
                                       ColumnMetadata('etl_created_at', 'description of etl_created_at', 'timestamp', 4),
-                                      ColumnMetadata('ds', None, 'varchar', 5)])
+                                      ColumnMetadata('ds', None, 'varchar', 5)], 0)
 
             self.assertEqual(expected.__repr__(), actual.__repr__())
             self.assertIsNone(extractor.extract())
@@ -102,6 +104,7 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
             table = {'schema': 'test_schema1',
                      'name': 'test_table1',
                      'description': 'test table 1',
+                     'is_view': 0,
                      'cluster':
                          self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
                      }
@@ -109,6 +112,7 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
             table1 = {'schema': 'test_schema1',
                       'name': 'test_table2',
                       'description': 'test table 2',
+                      'is_view': 0,
                       'cluster':
                           self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
                       }
@@ -116,6 +120,7 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
             table2 = {'schema': 'test_schema2',
                       'name': 'test_table3',
                       'description': 'test table 3',
+                      'is_view': 0,
                       'cluster':
                           self.conf[PostgresMetadataExtractor.CLUSTER_KEY]
                       }
@@ -123,52 +128,52 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
             sql_execute.return_value = [
                 self._union(
                     {'col_name': 'col_id1',
-                     'col_type': 'bigint',
+                     'data_type': 'bigint',
                      'col_description': 'description of col_id1',
                      'col_sort_order': 0}, table),
                 self._union(
                     {'col_name': 'col_id2',
-                     'col_type': 'bigint',
+                     'data_type': 'bigint',
                      'col_description': 'description of col_id2',
                      'col_sort_order': 1}, table),
                 self._union(
                     {'col_name': 'is_active',
-                     'col_type': 'boolean',
+                     'data_type': 'boolean',
                      'col_description': None,
                      'col_sort_order': 2}, table),
                 self._union(
                     {'col_name': 'source',
-                     'col_type': 'varchar',
+                     'data_type': 'varchar',
                      'col_description': 'description of source',
                      'col_sort_order': 3}, table),
                 self._union(
                     {'col_name': 'etl_created_at',
-                     'col_type': 'timestamp',
+                     'data_type': 'timestamp',
                      'col_description': 'description of etl_created_at',
                      'col_sort_order': 4}, table),
                 self._union(
                     {'col_name': 'ds',
-                     'col_type': 'varchar',
+                     'data_type': 'varchar',
                      'col_description': None,
                      'col_sort_order': 5}, table),
                 self._union(
                     {'col_name': 'col_name',
-                     'col_type': 'varchar',
+                     'data_type': 'varchar',
                      'col_description': 'description of col_name',
                      'col_sort_order': 0}, table1),
                 self._union(
                     {'col_name': 'col_name2',
-                     'col_type': 'varchar',
+                     'data_type': 'varchar',
                      'col_description': 'description of col_name2',
                      'col_sort_order': 1}, table1),
                 self._union(
                     {'col_name': 'col_id3',
-                     'col_type': 'varchar',
+                     'data_type': 'varchar',
                      'col_description': 'description of col_id3',
                      'col_sort_order': 0}, table2),
                 self._union(
                     {'col_name': 'col_name3',
-                     'col_type': 'varchar',
+                     'data_type': 'varchar',
                      'col_description': 'description of col_name3',
                      'col_sort_order': 1}, table2)
             ]
@@ -184,14 +189,14 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
                                       ColumnMetadata('is_active', None, 'boolean', 2),
                                       ColumnMetadata('source', 'description of source', 'varchar', 3),
                                       ColumnMetadata('etl_created_at', 'description of etl_created_at', 'timestamp', 4),
-                                      ColumnMetadata('ds', None, 'varchar', 5)])
+                                      ColumnMetadata('ds', None, 'varchar', 5)], 0)
             self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
 
             expected = TableMetadata('postgres',
                                      self.conf[PostgresMetadataExtractor.CLUSTER_KEY],
                                      'test_schema1', 'test_table2', 'test table 2',
                                      [ColumnMetadata('col_name', 'description of col_name', 'varchar', 0),
-                                      ColumnMetadata('col_name2', 'description of col_name2', 'varchar', 1)])
+                                      ColumnMetadata('col_name2', 'description of col_name2', 'varchar', 1)], 0)
             self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
 
             expected = TableMetadata('postgres',
@@ -199,7 +204,7 @@ class TestPostgresMetadataExtractor(unittest.TestCase):
                                      'test_schema2', 'test_table3', 'test table 3',
                                      [ColumnMetadata('col_id3', 'description of col_id3', 'varchar', 0),
                                       ColumnMetadata('col_name3', 'description of col_name3',
-                                                     'varchar', 1)])
+                                                     'varchar', 1)], 0)
             self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
 
             self.assertIsNone(extractor.extract())

--- a/pipelines/tests/unit/extractor/test_presto_loop_extractor.py
+++ b/pipelines/tests/unit/extractor/test_presto_loop_extractor.py
@@ -72,7 +72,7 @@ class TestPrestoLoopExtractor(unittest.TestCase):
                 ColumnMetadata(
                     name=MOCK_COLUMN_RESULT[0],
                     description=MOCK_COLUMN_RESULT[3],
-                    col_type=MOCK_COLUMN_RESULT[1],
+                    data_type=MOCK_COLUMN_RESULT[1],
                     sort_order=0,
                     is_partition_column=is_partition_column,
                 )

--- a/pipelines/tests/unit/extractor/test_snowflake_metadata_extractor.py
+++ b/pipelines/tests/unit/extractor/test_snowflake_metadata_extractor.py
@@ -7,7 +7,8 @@ from typing import Any, Dict  # noqa: F401
 
 from whale.extractor.snowflake_metadata_extractor import SnowflakeMetadataExtractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from whale.models.table_metadata import TableMetadata, ColumnMetadata
+from whale.models.table_metadata import TableMetadata
+from whale.models.column_metadata import ColumnMetadata
 
 
 class TestSnowflakeMetadataExtractor(unittest.TestCase):
@@ -55,7 +56,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "col_id1",
-                        "col_type": "number",
+                        "data_type": "number",
                         "col_description": "description of id1",
                         "col_sort_order": 0,
                     },
@@ -64,7 +65,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "col_id2",
-                        "col_type": "number",
+                        "data_type": "number",
                         "col_description": "description of id2",
                         "col_sort_order": 1,
                     },
@@ -73,7 +74,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "is_active",
-                        "col_type": "boolean",
+                        "data_type": "boolean",
                         "col_description": None,
                         "col_sort_order": 2,
                     },
@@ -82,7 +83,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "source",
-                        "col_type": "varchar",
+                        "data_type": "varchar",
                         "col_description": "description of source",
                         "col_sort_order": 3,
                     },
@@ -91,7 +92,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "etl_created_at",
-                        "col_type": "timestamp_ltz",
+                        "data_type": "timestamp_ltz",
                         "col_description": "description of etl_created_at",
                         "col_sort_order": 4,
                     },
@@ -100,7 +101,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "ds",
-                        "col_type": "varchar",
+                        "data_type": "varchar",
                         "col_description": None,
                         "col_sort_order": 5,
                     },
@@ -170,7 +171,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "col_id1",
-                        "col_type": "number",
+                        "data_type": "number",
                         "col_description": "description of col_id1",
                         "col_sort_order": 0,
                     },
@@ -179,7 +180,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "col_id2",
-                        "col_type": "number",
+                        "data_type": "number",
                         "col_description": "description of col_id2",
                         "col_sort_order": 1,
                     },
@@ -188,7 +189,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "is_active",
-                        "col_type": "boolean",
+                        "data_type": "boolean",
                         "col_description": None,
                         "col_sort_order": 2,
                     },
@@ -197,7 +198,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "source",
-                        "col_type": "varchar",
+                        "data_type": "varchar",
                         "col_description": "description of source",
                         "col_sort_order": 3,
                     },
@@ -206,7 +207,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "etl_created_at",
-                        "col_type": "timestamp_ltz",
+                        "data_type": "timestamp_ltz",
                         "col_description": "description of etl_created_at",
                         "col_sort_order": 4,
                     },
@@ -215,7 +216,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "ds",
-                        "col_type": "varchar",
+                        "data_type": "varchar",
                         "col_description": None,
                         "col_sort_order": 5,
                     },
@@ -224,7 +225,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "col_name",
-                        "col_type": "varchar",
+                        "data_type": "varchar",
                         "col_description": "description of col_name",
                         "col_sort_order": 0,
                     },
@@ -233,7 +234,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "col_name2",
-                        "col_type": "varchar",
+                        "data_type": "varchar",
                         "col_description": "description of col_name2",
                         "col_sort_order": 1,
                     },
@@ -242,7 +243,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "col_id3",
-                        "col_type": "varchar",
+                        "data_type": "varchar",
                         "col_description": "description of col_id3",
                         "col_sort_order": 0,
                     },
@@ -251,7 +252,7 @@ class TestSnowflakeMetadataExtractor(unittest.TestCase):
                 self._union(
                     {
                         "col_name": "col_name3",
-                        "col_type": "varchar",
+                        "data_type": "varchar",
                         "col_description": "description of col_name3",
                         "col_sort_order": 1,
                     },

--- a/pipelines/tests/unit/extractor/test_spanner_metadata_extractor.py
+++ b/pipelines/tests/unit/extractor/test_spanner_metadata_extractor.py
@@ -8,7 +8,8 @@ from pyhocon import ConfigFactory
 from databuilder import Scoped
 from whale.extractor.spanner_metadata_extractor import SpannerMetadataExtractor
 from whale.extractor.spanner_metadata_extractor import spanner
-from whale.models.table_metadata import TableMetadata, ColumnMetadata
+from whale.models.table_metadata import TableMetadata
+from whale.models.column_metadata import ColumnMetadata
 
 logging.basicConfig(level=logging.INFO)
 

--- a/pipelines/tests/unit/extractor/test_splice_machine_metadata_extractor.py
+++ b/pipelines/tests/unit/extractor/test_splice_machine_metadata_extractor.py
@@ -6,7 +6,8 @@ from pyhocon import ConfigFactory
 
 from whale.extractor.splice_machine_metadata_extractor import SpliceMachineMetadataExtractor
 from whale.extractor import splice_machine_metadata_extractor
-from whale.models.table_metadata import TableMetadata, ColumnMetadata
+from whale.models.table_metadata import TableMetadata
+from whale.models.column_metadata import ColumnMetadata
 
 
 class TestSpliceMachineMetadataExtractor(unittest.TestCase):

--- a/pipelines/tests/unit/utils/test_extractor_wrappers.py
+++ b/pipelines/tests/unit/utils/test_extractor_wrappers.py
@@ -11,9 +11,7 @@ from whale.models.connection_config import ConnectionConfigSchema
 from whale.engine.sql_alchemy_engine import SQLAlchemyEngine
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 from whale.extractor.bigquery_metadata_extractor import BaseBigQueryExtractor
-from databuilder.extractor.base_postgres_metadata_extractor import (
-    BasePostgresMetadataExtractor,
-)
+from whale.extractor.base_postgres_metadata_extractor import BasePostgresMetadataExtractor
 from whale.utils.extractor_wrappers import (
     configure_bigquery_extractors,
     configure_glue_extractors,

--- a/pipelines/whale/engine/mixins/presto_commands_mixin.py
+++ b/pipelines/whale/engine/mixins/presto_commands_mixin.py
@@ -5,7 +5,9 @@ from itertools import groupby
 from typing import Dict, Iterable, Iterator, List, Optional, NamedTuple  # noqa: F821
 
 from whale.models.presto_watermark import PrestoWatermark
-from whale.models.table_metadata import ColumnMetadata, TableColumnStats, TableMetadata
+from whale.models.table_metadata import TableMetadata
+from whale.models.column_metadata import ColumnMetadata
+from whale.models.table_column_stats import TableColumnStats
 
 
 LOGGER = logging.getLogger(__name__)
@@ -66,7 +68,7 @@ class PrestoCommandsMixin:
           , a.ordinal_position as col_sort_order
           , IF(a.extra_info = 'partition key', 1, 0) AS is_partition_col
           , a.comment AS col_description
-          , a.data_type AS col_type
+          , a.data_type
           , IF(b.table_name is not null, 1, 0) AS is_view
         FROM {cluster_prefix}information_schema.columns a
         LEFT JOIN {cluster_prefix}information_schema.views b
@@ -102,7 +104,7 @@ class PrestoCommandsMixin:
                     ColumnMetadata(
                         row["col_name"],
                         row["col_description"],
-                        row["col_type"],
+                        row["data_type"],
                         row["col_sort_order"],
                     )
                 )
@@ -139,7 +141,7 @@ class PrestoCommandsMixin:
                 ColumnMetadata(
                     name=column_dict["Column"],
                     description=column_dict["Comment"],
-                    col_type=column_dict["Type"],
+                    data_type=column_dict["Type"],
                     sort_order=i,
                     is_partition_column=column_dict["Extra"] == "partition key",
                 )

--- a/pipelines/whale/extractor/amundsen_neo4j_metadata_extractor.py
+++ b/pipelines/whale/extractor/amundsen_neo4j_metadata_extractor.py
@@ -2,7 +2,8 @@ from itertools import zip_longest
 from pyhocon import ConfigTree
 
 from databuilder.extractor.neo4j_extractor import Neo4jExtractor
-from whale.models.table_metadata import TableMetadata, ColumnMetadata
+from whale.models.table_metadata import TableMetadata
+from whale.models.column_metadata import ColumnMetadata
 from whale.utils.neo4j import combine_where_clauses
 
 
@@ -139,7 +140,7 @@ class AmundsenNeo4jMetadataExtractor(Neo4jExtractor):
                         ColumnMetadata(
                             name=column_name,
                             description=column_description,
-                            col_type=column_type,
+                            data_type=column_type,
                             sort_order=column_sort_order,
                             is_partition_column=is_partition_column,
                         )

--- a/pipelines/whale/extractor/base_postgres_metadata_extractor.py
+++ b/pipelines/whale/extractor/base_postgres_metadata_extractor.py
@@ -1,0 +1,116 @@
+# Copyright Contributors to the Amundsen project.
+# SPDX-License-Identifier: Apache-2.0
+
+import abc
+import logging
+from collections import namedtuple
+
+from pyhocon import ConfigFactory, ConfigTree
+from typing import Iterator, Union, Dict, Any
+
+from databuilder import Scoped
+from databuilder.extractor.base_extractor import Extractor
+from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
+from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from itertools import groupby
+
+
+TableKey = namedtuple('TableKey', ['schema', 'table_name'])
+
+LOGGER = logging.getLogger(__name__)
+
+
+class BasePostgresMetadataExtractor(Extractor):
+    """
+    Extracts Postgres table and column metadata from underlying meta store database using SQLAlchemyExtractor
+    """
+
+    # CONFIG KEYS
+    WHERE_CLAUSE_SUFFIX_KEY = 'where_clause_suffix'
+    CLUSTER_KEY = 'cluster_key'
+    USE_CATALOG_AS_CLUSTER_NAME = 'use_catalog_as_cluster_name'
+    DATABASE_KEY = 'database_key'
+
+    # Default values
+    DEFAULT_CLUSTER_NAME = 'master'
+
+    DEFAULT_CONFIG = ConfigFactory.from_dict(
+        {WHERE_CLAUSE_SUFFIX_KEY: ' ', CLUSTER_KEY: DEFAULT_CLUSTER_NAME, USE_CATALOG_AS_CLUSTER_NAME: True}
+    )
+
+    @abc.abstractmethod
+    def get_sql_statement(self, use_catalog_as_cluster_name: bool, where_clause_suffix: str) -> Any:
+        """
+        :return: Provides a record or None if no more to extract
+        """
+        return None
+
+    def init(self, conf: ConfigTree) -> None:
+        conf = conf.with_fallback(BasePostgresMetadataExtractor.DEFAULT_CONFIG)
+        self._cluster = '{}'.format(conf.get_string(BasePostgresMetadataExtractor.CLUSTER_KEY))
+
+        self._database = conf.get_string(BasePostgresMetadataExtractor.DATABASE_KEY, default='postgres')
+
+        self.sql_stmt = self.get_sql_statement(
+            use_catalog_as_cluster_name=conf.get_bool(BasePostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME),
+            where_clause_suffix=conf.get_string(BasePostgresMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY),
+        )
+
+        self._alchemy_extractor = SQLAlchemyExtractor()
+        sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope())\
+            .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
+
+        self.sql_stmt = sql_alch_conf.get_string(SQLAlchemyExtractor.EXTRACT_SQL)
+
+        LOGGER.info('SQL for postgres metadata: {}'.format(self.sql_stmt))
+
+        self._alchemy_extractor.init(sql_alch_conf)
+        self._extract_iter: Union[None, Iterator] = None
+
+    def extract(self) -> Union[TableMetadata, None]:
+        if not self._extract_iter:
+            self._extract_iter = self._get_extract_iter()
+        try:
+            return next(self._extract_iter)
+        except StopIteration:
+            return None
+
+    def _get_extract_iter(self) -> Iterator[TableMetadata]:
+        """
+        Using itertools.groupby and raw level iterator, it groups to table and yields TableMetadata
+        :return:
+        """
+        for key, group in groupby(self._get_raw_extract_iter(), self._get_table_key):
+            columns = []
+
+            for row in group:
+                last_row = row
+                columns.append(ColumnMetadata(row['col_name'], row['col_description'],
+                                              row['data_type'], row['col_sort_order']))
+
+            yield TableMetadata(self._database, last_row['cluster'],
+                                last_row['schema'],
+                                last_row['name'],
+                                last_row['description'],
+                                columns)
+
+    def _get_raw_extract_iter(self) -> Iterator[Dict[str, Any]]:
+        """
+        Provides iterator of result row from SQLAlchemy extractor
+        :return:
+        """
+        row = self._alchemy_extractor.extract()
+        while row:
+            yield row
+            row = self._alchemy_extractor.extract()
+
+    def _get_table_key(self, row: Dict[str, Any]) -> Union[TableKey, None]:
+        """
+        Table key consists of schema and table name
+        :param row:
+        :return:
+        """
+        if row:
+            return TableKey(schema=row['schema'], table_name=row['name'])
+
+        return None

--- a/pipelines/whale/extractor/bigquery_metadata_extractor.py
+++ b/pipelines/whale/extractor/bigquery_metadata_extractor.py
@@ -6,7 +6,8 @@ from pyhocon import ConfigTree  # noqa: F401
 from typing import List, Any  # noqa: F401
 
 from whale.extractor.base_bigquery_extractor import BaseBigQueryExtractor
-from whale.models.table_metadata import TableMetadata, ColumnMetadata
+from whale.models.table_metadata import TableMetadata
+from whale.models.column_metadata import ColumnMetadata
 
 
 DatasetRef = namedtuple("DatasetRef", ["datasetId", "projectId"])
@@ -147,7 +148,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
             col = ColumnMetadata(
                 name=col_name,
                 description=column.get("description", ""),
-                col_type=column["type"],
+                data_type=column["type"],
                 sort_order=total_cols,
                 tags=tags,
             )
@@ -162,7 +163,7 @@ class BigQueryMetadataExtractor(BaseBigQueryExtractor):
             col = ColumnMetadata(
                 name=col_name,
                 description=column.get("description", ""),
-                col_type=column["type"],
+                data_type=column["type"],
                 sort_order=total_cols,
                 tags=tags,
             )

--- a/pipelines/whale/extractor/glue_extractor.py
+++ b/pipelines/whale/extractor/glue_extractor.py
@@ -2,7 +2,8 @@ import boto3
 from databuilder.extractor.base_extractor import Extractor
 from pyhocon import ConfigFactory, ConfigTree
 from typing import Any, Dict, Iterator, List, Union
-from whale.models.table_metadata import TableMetadata, ColumnMetadata
+from whale.models.column_metadata import ColumnMetadata
+from whale.models.table_metadata import TableMetadata
 
 
 class GlueExtractor(Extractor):

--- a/pipelines/whale/extractor/postgres_metadata_extractor.py
+++ b/pipelines/whale/extractor/postgres_metadata_extractor.py
@@ -7,10 +7,9 @@ from typing import (  # noqa: F401
 
 from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
 
-from databuilder.extractor.base_postgres_metadata_extractor import (
-    BasePostgresMetadataExtractor,
-)
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from whale.extractor.base_postgres_metadata_extractor import BasePostgresMetadataExtractor
+from whale.models.table_metadata import TableMetadata
+from whale.models.column_metadata import ColumnMetadata
 from itertools import groupby
 
 
@@ -30,7 +29,7 @@ class PostgresMetadataExtractor(BasePostgresMetadataExtractor):
         return """
         SELECT
             {cluster_source} as cluster, c.table_schema as schema, c.table_name as name, pgtd.description as description
-          , c.column_name as col_name, c.data_type as col_type
+          , c.column_name as col_name, c.data_type
           , pgcd.description as col_description, ordinal_position as col_sort_order
           , CASE WHEN b.table_name IS NOT NULL THEN 1 ELSE 0 END AS is_view
         FROM INFORMATION_SCHEMA.COLUMNS c
@@ -62,7 +61,7 @@ class PostgresMetadataExtractor(BasePostgresMetadataExtractor):
             for row in group:
                 last_row = row
                 columns.append(ColumnMetadata(row['col_name'], row['col_description'],
-                                              row['col_type'], row['col_sort_order']))
+                                              row['data_type'], row['col_sort_order']))
 
             # Deviating from amundsen to add `is_view`
             yield TableMetadata(self._database, last_row['cluster'],

--- a/pipelines/whale/extractor/postgres_metadata_extractor.py
+++ b/pipelines/whale/extractor/postgres_metadata_extractor.py
@@ -7,7 +7,9 @@ from typing import (  # noqa: F401
 
 from pyhocon import ConfigFactory, ConfigTree  # noqa: F401
 
-from whale.extractor.base_postgres_metadata_extractor import BasePostgresMetadataExtractor
+from whale.extractor.base_postgres_metadata_extractor import (
+    BasePostgresMetadataExtractor,
+)
 from whale.models.table_metadata import TableMetadata
 from whale.models.column_metadata import ColumnMetadata
 from itertools import groupby
@@ -60,15 +62,25 @@ class PostgresMetadataExtractor(BasePostgresMetadataExtractor):
 
             for row in group:
                 last_row = row
-                columns.append(ColumnMetadata(row['col_name'], row['col_description'],
-                                              row['data_type'], row['col_sort_order']))
+                columns.append(
+                    ColumnMetadata(
+                        row["col_name"],
+                        row["col_description"],
+                        row["data_type"],
+                        row["col_sort_order"],
+                    )
+                )
 
             # Deviating from amundsen to add `is_view`
-            yield TableMetadata(self._database, last_row['cluster'],
-                                last_row['schema'],
-                                last_row['name'],
-                                last_row['description'],
-                                columns, last_row['is_view'])
+            yield TableMetadata(
+                self._database,
+                last_row["cluster"],
+                last_row["schema"],
+                last_row["name"],
+                last_row["description"],
+                columns,
+                last_row["is_view"],
+            )
 
     def get_scope(self) -> str:
         return "extractor.postgres_metadata"

--- a/pipelines/whale/extractor/presto_table_metadata_extractor.py
+++ b/pipelines/whale/extractor/presto_table_metadata_extractor.py
@@ -7,7 +7,8 @@ from typing import Iterator, Union, Dict, Any  # noqa: F401
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
+from whale.models.table_metadata import TableMetadata
+from whale.models.column_metadata import ColumnMetadata
 from itertools import groupby
 
 
@@ -35,7 +36,7 @@ class PrestoTableMetadataExtractor(Extractor):
       , a.ordinal_position as col_sort_order
       , IF(a.extra_info = 'partition key', 1, 0) AS is_partition_col
       , a.comment AS col_description
-      , a.data_type AS col_type
+      , a.data_type
       , IF(b.table_name is not null, 1, 0) AS is_view
     FROM {cluster_prefix}information_schema.columns a
     LEFT JOIN {cluster_prefix}information_schema.views b ON a.table_catalog = b.table_catalog
@@ -114,7 +115,7 @@ class PrestoTableMetadataExtractor(Extractor):
                     ColumnMetadata(
                         row["col_name"],
                         row["col_description"],
-                        row["col_type"],
+                        row["data_type"],
                         row["col_sort_order"],
                     )
                 )

--- a/pipelines/whale/extractor/snowflake_metadata_extractor.py
+++ b/pipelines/whale/extractor/snowflake_metadata_extractor.py
@@ -8,7 +8,8 @@ from unidecode import unidecode
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
-from whale.models.table_metadata import TableMetadata, ColumnMetadata
+from whale.models.table_metadata import TableMetadata
+from whale.models.column_metadata import ColumnMetadata
 from itertools import groupby
 
 
@@ -30,7 +31,7 @@ class SnowflakeMetadataExtractor(Extractor):
     SELECT
         lower(c.column_name) AS col_name,
         c.comment AS col_description,
-        lower(c.data_type) AS col_type,
+        lower(c.data_type) AS data_type,
         lower(c.ordinal_position) AS col_sort_order,
         lower('{database}') AS database,
         lower(c.table_catalog) AS cluster,
@@ -112,7 +113,7 @@ class SnowflakeMetadataExtractor(Extractor):
                     ColumnMetadata(
                         name=row["col_name"],
                         description=column_description,
-                        col_type=row["col_type"],
+                        data_type=row["data_type"],
                         sort_order=row["col_sort_order"],
                     )
                 )

--- a/pipelines/whale/extractor/spanner_metadata_extractor.py
+++ b/pipelines/whale/extractor/spanner_metadata_extractor.py
@@ -7,7 +7,8 @@ from typing import Iterator, Union, Dict, Any  # noqa: F401
 
 from databuilder import Scoped
 from databuilder.extractor.base_extractor import Extractor
-from whale.models.table_metadata import TableMetadata, ColumnMetadata
+from whale.models.table_metadata import TableMetadata
+from whale.models.column_metadata import ColumnMetadata
 from itertools import groupby
 
 
@@ -32,7 +33,7 @@ class SpannerMetadataExtractor(Extractor):
     SQL_STATEMENT = """
     SELECT
       lower(c.column_name) AS col_name,
-      lower(c.spanner_type) AS col_type,
+      lower(c.spanner_type) AS data_type,
       c.ordinal_position AS col_sort_order,
       lower(c.table_schema) AS `schema`,
       lower(c.table_name) AS name
@@ -46,7 +47,7 @@ class SpannerMetadataExtractor(Extractor):
     ORDER by `schema`, name, col_sort_order ;
     """
 
-    HEADER = ["col_name", "col_type", "col_sort_order", "schema", "name"]
+    HEADER = ["col_name", "data_type", "col_sort_order", "schema", "name"]
 
     # Config keys.
     DEFAULT_CONFIG = ConfigFactory.from_dict(
@@ -126,7 +127,7 @@ class SpannerMetadataExtractor(Extractor):
                         ColumnMetadata(
                             row["col_name"],
                             None,
-                            row["col_type"],
+                            row["data_type"],
                             row["col_sort_order"],
                         )
                     )

--- a/pipelines/whale/extractor/splice_machine_metadata_extractor.py
+++ b/pipelines/whale/extractor/splice_machine_metadata_extractor.py
@@ -7,7 +7,8 @@ from pyhocon import ConfigFactory, ConfigTree
 from typing import Any, Dict, Iterator, Optional
 
 from databuilder.extractor.base_extractor import Extractor
-from whale.models.table_metadata import TableMetadata, ColumnMetadata
+from whale.models.table_metadata import TableMetadata
+from whale.models.column_metadata import ColumnMetadata
 from itertools import groupby
 from splicemachinesa.pyodbc import splice_connect
 
@@ -88,7 +89,7 @@ class SpliceMachineMetadataExtractor(Extractor):
                     ColumnMetadata(
                         name=row["column_name"],
                         description=None,
-                        col_type=row["column_type"],
+                        data_type=row["column_type"],
                         sort_order=row["column_sort_order"],
                     )
                 )

--- a/pipelines/whale/loader/whale_loader.py
+++ b/pipelines/whale/loader/whale_loader.py
@@ -278,33 +278,33 @@ def format_columns(record) -> str:
     max_type_length = 9
     columns = record.columns
 
-    if columns:
-        column_template_no_desc = "* {buffered_type} `{name}`"
-        column_template = column_template_no_desc + "\n  - {description}"
-        formatted_columns_list = []
-
-        for column in columns:
-            buffer_length = max(max_type_length - len(column.type), 0)
-            buffered_type = "[" + column.type + "]" + " " * buffer_length
-
-            if column.description:
-                formatted_column_text = column_template.format(
-                    buffered_type=buffered_type,
-                    name=column.name,
-                    description=column.description,
-                )
-            else:
-                formatted_column_text = column_template_no_desc.format(
-                    buffered_type=buffered_type,
-                    name=column.name,
-                )
-
-            formatted_columns_list.append(formatted_column_text)
-
-        formatted_columns = "\n".join(formatted_columns_list)
-        return formatted_columns
-    else:
+    if not columns:
         return ""
+
+    column_template_no_desc = "* {buffered_type} `{name}`"
+    column_template = column_template_no_desc + "\n  - {description}"
+    formatted_columns_list = []
+
+    for column in columns:
+        buffer_length = max(max_type_length - len(column.type), 0)
+        buffered_type = "[" + column.type + "]" + " " * buffer_length
+
+        if column.description:
+            formatted_column_text = column_template.format(
+                buffered_type=buffered_type,
+                name=column.name,
+                description=column.description,
+            )
+        else:
+            formatted_column_text = column_template_no_desc.format(
+                buffered_type=buffered_type,
+                name=column.name,
+            )
+
+        formatted_columns_list.append(formatted_column_text)
+
+    formatted_columns = "\n".join(formatted_columns_list)
+    return formatted_columns
 
 
 def _get_metrics_from_section(section):

--- a/pipelines/whale/models/column_metadata.py
+++ b/pipelines/whale/models/column_metadata.py
@@ -1,0 +1,40 @@
+from typing import Dict, Iterable, List, Optional, Union
+
+class ColumnMetadata:
+    COLUMN_KEY_FORMAT = "{db}://{cluster}.{schema}.{tbl}/{col}"
+
+    def __init__(
+        self,
+        name: str,
+        description: Optional[str],
+        data_type: str,
+        sort_order: int,
+        tags: Optional[Union[List[Dict], List[str]]] = None,
+        is_partition_column: Optional[bool] = None,
+    ):
+        # type: (...) -> None
+        """
+        :param name: Name of the column
+        :param description: Description of the column
+        :param data_type: Data type of the column, e.g. integer or bool.
+        :param sort_order: Rank of the column
+        """
+        self.name = name
+        self.description = description
+        self.type = data_type
+        self.sort_order = sort_order
+        self.tags = tags
+        self.is_partition_column = is_partition_column
+
+    def __repr__(self):
+        # type: () -> str
+        return "ColumnMetadata({!r}, {!r}, {!r}, {!r}, {!r}, {!r})".format(
+            self.name,
+            self.description,
+            self.type,
+            self.sort_order,
+            self.tags,
+            self.is_partition_column,
+        )
+
+

--- a/pipelines/whale/models/presto_watermark.py
+++ b/pipelines/whale/models/presto_watermark.py
@@ -1,6 +1,6 @@
 from typing import Any, Dict, List, Union  # noqa: F401
 
-from databuilder.models.table_metadata import ColumnMetadata
+from whale.models.column_metadata import ColumnMetadata
 
 
 class PrestoWatermark(object):

--- a/pipelines/whale/models/table_column_stats.py
+++ b/pipelines/whale/models/table_column_stats.py
@@ -1,0 +1,59 @@
+from typing import Dict, Iterable, List, Optional, Union
+from whale.models.column_metadata import ColumnMetadata
+
+class TableColumnStats:
+    """
+    Table stats model.
+    """
+
+    LABEL = "Stat"
+    KEY_FORMAT = "{db}://{cluster}.{schema}" ".{table}/{col}/{stat_name}/"
+    STAT_Column_RELATION_TYPE = "STAT_OF"
+    Column_STAT_RELATION_TYPE = "STAT"
+
+    def __init__(
+        self,
+        table_name: str,
+        col_name: str,
+        stat_name: str,
+        stat_val: str,
+        start_epoch: str,
+        end_epoch: str,
+        db: str = "hive",
+        cluster: str = "gold",
+        schema: str = None,
+    ):
+        if schema is None:
+            self.schema, self.table = table_name.split(".")
+        else:
+            self.table = table_name.lower()
+            self.schema = schema.lower()
+        self.db = db
+        self.col_name = col_name.lower()
+        self.start_epoch = start_epoch
+        self.end_epoch = end_epoch
+        self.cluster = cluster
+        self.stat_name = stat_name
+        self.stat_val = stat_val
+
+    def get_table_stat_model_key(self):
+        # type: (...) -> str
+        return TableColumnStats.KEY_FORMAT.format(
+            db=self.db,
+            cluster=self.cluster,
+            schema=self.schema,
+            table=self.table,
+            col=self.col_name,
+            stat_name=self.stat_name,
+        )
+
+    def get_col_key(self):
+        # type: (...) -> str
+        # no cluster, schema info from the input
+        return ColumnMetadata.COLUMN_KEY_FORMAT.format(
+            db=self.db,
+            cluster=self.cluster,
+            schema=self.schema,
+            tbl=self.table,
+            col=self.col_name,
+        )

--- a/pipelines/whale/models/table_metadata.py
+++ b/pipelines/whale/models/table_metadata.py
@@ -1,45 +1,6 @@
 import copy
-
 from typing import Dict, Iterable, List, Optional, Union
-
-
-class ColumnMetadata:
-    COLUMN_KEY_FORMAT = "{db}://{cluster}.{schema}.{tbl}/{col}"
-
-    def __init__(
-        self,
-        name: str,
-        description: Optional[str],
-        col_type: str,
-        sort_order: int,
-        tags: Optional[Union[List[Dict], List[str]]] = None,
-        is_partition_column: Optional[bool] = None,
-    ):
-        # type: (...) -> None
-        """
-        :param name:
-        :param description:
-        :param col_type:
-        :param sort_order:
-        """
-        self.name = name
-        self.description = description
-        self.type = col_type
-        self.sort_order = sort_order
-        self.tags = tags
-        self.is_partition_column = is_partition_column
-
-    def __repr__(self):
-        # type: () -> str
-        return "ColumnMetadata({!r}, {!r}, {!r}, {!r}, {!r}, {!r})".format(
-            self.name,
-            self.description,
-            self.type,
-            self.sort_order,
-            self.tags,
-            self.is_partition_column,
-        )
-
+from whale.models.column_metadata import ColumnMetadata
 
 class TableMetadata(object):
     """
@@ -141,59 +102,3 @@ class TableMetadata(object):
         )
 
 
-class TableColumnStats:
-    """
-    Table stats model.
-    """
-
-    LABEL = "Stat"
-    KEY_FORMAT = "{db}://{cluster}.{schema}" ".{table}/{col}/{stat_name}/"
-    STAT_Column_RELATION_TYPE = "STAT_OF"
-    Column_STAT_RELATION_TYPE = "STAT"
-
-    def __init__(
-        self,
-        table_name: str,
-        col_name: str,
-        stat_name: str,
-        stat_val: str,
-        start_epoch: str,
-        end_epoch: str,
-        db: str = "hive",
-        cluster: str = "gold",
-        schema: str = None,
-    ):
-        if schema is None:
-            self.schema, self.table = table_name.split(".")
-        else:
-            self.table = table_name.lower()
-            self.schema = schema.lower()
-        self.db = db
-        self.col_name = col_name.lower()
-        self.start_epoch = start_epoch
-        self.end_epoch = end_epoch
-        self.cluster = cluster
-        self.stat_name = stat_name
-        self.stat_val = stat_val
-
-    def get_table_stat_model_key(self):
-        # type: (...) -> str
-        return TableColumnStats.KEY_FORMAT.format(
-            db=self.db,
-            cluster=self.cluster,
-            schema=self.schema,
-            table=self.table,
-            col=self.col_name,
-            stat_name=self.stat_name,
-        )
-
-    def get_col_key(self):
-        # type: (...) -> str
-        # no cluster, schema info from the input
-        return ColumnMetadata.COLUMN_KEY_FORMAT.format(
-            db=self.db,
-            cluster=self.cluster,
-            schema=self.schema,
-            tbl=self.table,
-            col=self.col_name,
-        )


### PR DESCRIPTION
Some cleanup of `table_metadata.py`:
- I pulled `ColumnMetadata` out into a separate file.
- I pulled `TableColumnStats` out into a separate file.
- I renamed `col_type` to `data_type`: It took me some time at first to understand the responsibility of this class attribute and I think the correct term would be `data_type`. 
- In `pipelines/tests/unit/extractor/test_postgres_metadata_extractor.py` I am now importing `PostgresMetadataExtractor` from whale and no longer from the databuilder package. This meant all test cases needed the `is_view` field.
- One small refactor inside `whale_loader.py` which should improve readability