### PR TITLE
Add index metadata for PostgreSQL

### DIFF
--- a/pipelines/tests/unit/extractor/test_postgres_index_extractor.py
+++ b/pipelines/tests/unit/extractor/test_postgres_index_extractor.py
@@ -1,0 +1,318 @@
+import logging
+import unittest
+from typing import Any, Dict
+from mock import MagicMock, patch
+from pyhocon import ConfigFactory
+
+from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
+
+from whale.extractor.postgres_index_extractor import PostgresIndexExtractor
+from whale.models.index_metadata import IndexMetadata
+
+
+class TestPostgresIndexExtractor(unittest.TestCase):
+    def setUp(self) -> None:
+        logging.basicConfig(level=logging.INFO)
+
+        config_dict = {
+            f"extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}": "TEST_CONNECTION",
+            PostgresIndexExtractor.CLUSTER_KEY: "MY_CLUSTER",
+            PostgresIndexExtractor.USE_CATALOG_AS_CLUSTER_NAME: False,
+            PostgresIndexExtractor.DATABASE_KEY: "postgres",
+        }
+
+        self.conf = ConfigFactory.from_dict(config_dict)
+
+    def test_extraction_with_empty_query_result(self) -> None:
+        with patch.object(SQLAlchemyExtractor, "_get_connection"):
+            extractor = PostgresIndexExtractor()
+            extractor.init(self.conf)
+
+            results = extractor.extract()
+            self.assertEqual(results, None)
+
+    def test_extraction_with_single_result(self) -> None:
+        with patch.object(SQLAlchemyExtractor, "_get_connection") as mock_connection:
+            connection = MagicMock()
+            mock_connection.return_value = connection
+            sql_execute = MagicMock()
+            connection.execute = sql_execute
+
+            table = {
+                "cluster": self.conf[PostgresIndexExtractor.CLUSTER_KEY],
+                "schema": "test_schema",
+                "table": "test_table",
+            }
+
+            sql_execute.return_value = [
+                self._union(
+                    {
+                        "index_name": "idx_1",
+                        "is_primary": False,
+                        "is_clustered": False,
+                        "is_unique": True,
+                        "column_name": "idx_column_1",
+                    },
+                    table,
+                ),
+                self._union(
+                    {
+                        "index_name": "idx_1",
+                        "is_primary": False,
+                        "is_clustered": False,
+                        "is_unique": True,
+                        "column_name": "idx_column_2",
+                    },
+                    table,
+                ),
+            ]
+
+            extractor = PostgresIndexExtractor()
+            extractor.init(self.conf)
+            actual = extractor.extract()
+
+            expected = IndexMetadata(
+                database="postgres",
+                cluster="MY_CLUSTER",
+                schema="test_schema",
+                table="test_table",
+                name="idx_1",
+                description=None,
+                index_type=None,
+                architecture=None,
+                constraint="unique",
+                columns=["idx_column_1", "idx_column_2"],
+                tags=None,
+            )
+
+            self.assertEqual(expected.__repr__(), actual.__repr__())
+            self.assertIsNone(extractor.extract())
+
+    def test_extraction_with_multiple_result(self) -> None:
+        with patch.object(SQLAlchemyExtractor, "_get_connection") as mock_connection:
+            connection = MagicMock()
+            mock_connection.return_value = connection
+            sql_execute = MagicMock()
+            connection.execute = sql_execute
+
+            table_1 = {
+                "cluster": self.conf[PostgresIndexExtractor.CLUSTER_KEY],
+                "schema": "test_schema_1",
+                "table": "test_table_1",
+            }
+
+            table_2 = {
+                "cluster": self.conf[PostgresIndexExtractor.CLUSTER_KEY],
+                "schema": "test_schema_2",
+                "table": "test_table_2",
+            }
+
+            sql_execute.return_value = [
+                self._union(
+                    {
+                        "index_name": "idx_1",
+                        "is_primary": False,
+                        "is_clustered": False,
+                        "is_unique": True,
+                        "column_name": "idx_1_column_1",
+                    },
+                    table_1,
+                ),
+                self._union(
+                    {
+                        "index_name": "idx_1",
+                        "is_primary": False,
+                        "is_clustered": False,
+                        "is_unique": True,
+                        "column_name": "idx_1_column_2",
+                    },
+                    table_1,
+                ),
+                self._union(
+                    {
+                        "index_name": "idx_2",
+                        "is_primary": False,
+                        "is_clustered": False,
+                        "is_unique": True,
+                        "column_name": "idx_2_column_1",
+                    },
+                    table_1,
+                ),
+                self._union(
+                    {
+                        "index_name": "idx_3",
+                        "is_primary": False,
+                        "is_clustered": False,
+                        "is_unique": True,
+                        "column_name": "idx_3_column_1",
+                    },
+                    table_2,
+                ),
+                self._union(
+                    {
+                        "index_name": "idx_3",
+                        "is_primary": False,
+                        "is_clustered": False,
+                        "is_unique": True,
+                        "column_name": "idx_3_column_2",
+                    },
+                    table_2,
+                ),
+            ]
+
+            extractor = PostgresIndexExtractor()
+            extractor.init(self.conf)
+
+            expected = IndexMetadata(
+                database="postgres",
+                cluster="MY_CLUSTER",
+                schema="test_schema_1",
+                table="test_table_1",
+                name="idx_1",
+                description=None,
+                index_type=None,
+                architecture=None,
+                constraint="unique",
+                columns=["idx_1_column_1", "idx_1_column_2"],
+                tags=None,
+            )
+
+            self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
+
+            expected = IndexMetadata(
+                database="postgres",
+                cluster="MY_CLUSTER",
+                schema="test_schema_1",
+                table="test_table_1",
+                name="idx_2",
+                description=None,
+                index_type=None,
+                architecture=None,
+                constraint="unique",
+                columns=["idx_2_column_1"],
+                tags=None,
+            )
+
+            self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
+
+            expected = IndexMetadata(
+                database="postgres",
+                cluster="MY_CLUSTER",
+                schema="test_schema_2",
+                table="test_table_2",
+                name="idx_3",
+                description=None,
+                index_type=None,
+                architecture=None,
+                constraint="unique",
+                columns=["idx_3_column_1", "idx_3_column_2"],
+                tags=None,
+            )
+
+            self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
+            self.assertIsNone(extractor.extract())
+
+    def _union(self, target: Dict[Any, Any], extra: Dict[Any, Any]) -> Dict[Any, Any]:
+        target.update(extra)
+        return target
+
+
+class TestPostgresIndexExtractorWithWhereClause(unittest.TestCase):
+    def setUp(self) -> None:
+        logging.basicConfig(level=logging.INFO)
+        self.where_clause_suffix = """
+        where table_schema in ('public') and table_name = 'movies'
+        """
+
+        config_dict = {
+            PostgresIndexExtractor.WHERE_CLAUSE_SUFFIX_KEY: self.where_clause_suffix,
+            PostgresIndexExtractor.DATABASE_KEY: "postgres",
+            f"extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}": "TEST_CONNECTION",
+        }
+        self.conf = ConfigFactory.from_dict(config_dict)
+
+    def test_sql_statement(self) -> None:
+        """
+        Test Extraction with empty result from query
+        """
+        with patch.object(SQLAlchemyExtractor, "_get_connection"):
+            extractor = PostgresIndexExtractor()
+            extractor.init(self.conf)
+            self.assertTrue(self.where_clause_suffix in extractor.sql_stmt)
+
+
+class TestPostgresIndexExtractorClusterKeyNoTableCatalog(unittest.TestCase):
+    # test when USE_CATALOG_AS_CLUSTER_NAME is false and CLUSTER_KEY is specified
+    def setUp(self) -> None:
+        logging.basicConfig(level=logging.INFO)
+        self.cluster_key = "not_master"
+
+        config_dict = {
+            PostgresIndexExtractor.CLUSTER_KEY: self.cluster_key,
+            PostgresIndexExtractor.DATABASE_KEY: "postgres",
+            f"extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}": "TEST_CONNECTION",
+            PostgresIndexExtractor.USE_CATALOG_AS_CLUSTER_NAME: False,
+        }
+        self.conf = ConfigFactory.from_dict(config_dict)
+
+    def test_sql_statement(self) -> None:
+        """
+        Test Extraction with empty result from query
+        """
+        with patch.object(SQLAlchemyExtractor, "_get_connection"):
+            extractor = PostgresIndexExtractor()
+            extractor.init(self.conf)
+            self.assertTrue(self.cluster_key in extractor.sql_stmt)
+
+
+class TestPostgresIndexExtractorNoClusterKeyNoTableCatalog(unittest.TestCase):
+    # test when USE_CATALOG_AS_CLUSTER_NAME is false and CLUSTER_KEY is NOT specified
+    def setUp(self) -> None:
+        logging.basicConfig(level=logging.INFO)
+
+        config_dict = {
+            f"extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}": "TEST_CONNECTION",
+            PostgresIndexExtractor.DATABASE_KEY: "postgres",
+            PostgresIndexExtractor.USE_CATALOG_AS_CLUSTER_NAME: False,
+        }
+        self.conf = ConfigFactory.from_dict(config_dict)
+
+    def test_sql_statement(self) -> None:
+        """
+        Test Extraction with empty result from query
+        """
+        with patch.object(SQLAlchemyExtractor, "_get_connection"):
+            extractor = PostgresIndexExtractor()
+            extractor.init(self.conf)
+            self.assertTrue(
+                PostgresIndexExtractor.DEFAULT_CLUSTER_NAME in extractor.sql_stmt
+            )
+
+
+class TestPostgresIndexExtractorTableCatalogEnabled(unittest.TestCase):
+    # test when USE_CATALOG_AS_CLUSTER_NAME is true (CLUSTER_KEY should be ignored)
+    def setUp(self) -> None:
+        logging.basicConfig(level=logging.INFO)
+        self.cluster_key = "not_master"
+
+        config_dict = {
+            PostgresIndexExtractor.CLUSTER_KEY: self.cluster_key,
+            PostgresIndexExtractor.DATABASE_KEY: "postgres",
+            f"extractor.sqlalchemy.{SQLAlchemyExtractor.CONN_STRING}": "TEST_CONNECTION",
+            PostgresIndexExtractor.USE_CATALOG_AS_CLUSTER_NAME: True,
+        }
+        self.conf = ConfigFactory.from_dict(config_dict)
+
+    def test_sql_statement(self) -> None:
+        """
+        Test Extraction with empty result from query
+        """
+        with patch.object(SQLAlchemyExtractor, "_get_connection"):
+            extractor = PostgresIndexExtractor()
+            extractor.init(self.conf)
+            self.assertTrue("table_catalog" in extractor.sql_stmt)
+            self.assertFalse(self.cluster_key in extractor.sql_stmt)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pipelines/tests/unit/extractor/test_postgres_index_extractor.py
+++ b/pipelines/tests/unit/extractor/test_postgres_index_extractor.py
@@ -7,7 +7,7 @@ from pyhocon import ConfigFactory
 from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
 
 from whale.extractor.postgres_index_extractor import PostgresIndexExtractor
-from whale.models.index_metadata import IndexMetadata
+from whale.models.index_metadata import TableIndexesMetadata, IndexMetadata
 
 
 class TestPostgresIndexExtractor(unittest.TestCase):
@@ -71,11 +71,7 @@ class TestPostgresIndexExtractor(unittest.TestCase):
             extractor.init(self.conf)
             actual = extractor.extract()
 
-            expected = IndexMetadata(
-                database="postgres",
-                cluster="MY_CLUSTER",
-                schema="test_schema",
-                table="test_table",
+            expected_index = IndexMetadata(
                 name="idx_1",
                 description=None,
                 index_type=None,
@@ -83,6 +79,14 @@ class TestPostgresIndexExtractor(unittest.TestCase):
                 constraint="unique",
                 columns=["idx_column_1", "idx_column_2"],
                 tags=None,
+            )
+
+            expected = TableIndexesMetadata(
+                database="postgres",
+                cluster="MY_CLUSTER",
+                schema="test_schema",
+                table="test_table",
+                indexes=[expected_index],
             )
 
             self.assertEqual(expected.__repr__(), actual.__repr__())
@@ -163,11 +167,7 @@ class TestPostgresIndexExtractor(unittest.TestCase):
             extractor = PostgresIndexExtractor()
             extractor.init(self.conf)
 
-            expected = IndexMetadata(
-                database="postgres",
-                cluster="MY_CLUSTER",
-                schema="test_schema_1",
-                table="test_table_1",
+            expected_index_1 = IndexMetadata(
                 name="idx_1",
                 description=None,
                 index_type=None,
@@ -177,13 +177,7 @@ class TestPostgresIndexExtractor(unittest.TestCase):
                 tags=None,
             )
 
-            self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
-
-            expected = IndexMetadata(
-                database="postgres",
-                cluster="MY_CLUSTER",
-                schema="test_schema_1",
-                table="test_table_1",
+            expected_index_2 = IndexMetadata(
                 name="idx_2",
                 description=None,
                 index_type=None,
@@ -193,13 +187,17 @@ class TestPostgresIndexExtractor(unittest.TestCase):
                 tags=None,
             )
 
-            self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
-
-            expected = IndexMetadata(
+            expected = TableIndexesMetadata(
                 database="postgres",
                 cluster="MY_CLUSTER",
-                schema="test_schema_2",
-                table="test_table_2",
+                schema="test_schema_1",
+                table="test_table_1",
+                indexes=[expected_index_1, expected_index_2],
+            )
+
+            self.assertEqual(expected.__repr__(), extractor.extract().__repr__())
+
+            expected_index = IndexMetadata(
                 name="idx_3",
                 description=None,
                 index_type=None,
@@ -207,6 +205,14 @@ class TestPostgresIndexExtractor(unittest.TestCase):
                 constraint="unique",
                 columns=["idx_3_column_1", "idx_3_column_2"],
                 tags=None,
+            )
+
+            expected = TableIndexesMetadata(
+                database="postgres",
+                cluster="MY_CLUSTER",
+                schema="test_schema_2",
+                table="test_table_2",
+                indexes=[expected_index],
             )
 
             self.assertEqual(expected.__repr__(), extractor.extract().__repr__())

--- a/pipelines/tests/unit/loader/test_whale_loader.py
+++ b/pipelines/tests/unit/loader/test_whale_loader.py
@@ -7,7 +7,7 @@ from pyhocon import ConfigFactory
 from typing import Dict, Iterable, Any, Callable  # noqa: F401
 
 from whale.models.table_metadata import TableMetadata
-from whale.models.index_metadata import IndexMetadata
+from whale.models.index_metadata import TableIndexesMetadata, IndexMetadata
 from whale.loader import whale_loader
 from whale.utils import paths
 
@@ -77,13 +77,17 @@ def test_load_catalog_specified(patched_config):
     assert "mock_database" in written_record
 
 def test_load_index_metadata(patched_config):
-    record = IndexMetadata(
+    index_metadata = IndexMetadata(
+        name="mock_index",
+        columns=["mock_column_1", "mock_column_2"],
+    )
+
+    record = TableIndexesMetadata(
         database="mock_database",
         cluster="mock_catalog",
         schema="mock_schema",
         table="mock_table",
-        name="mock_index",
-        columns=['mock_column_1', 'mock_column_2'],
+        indexes=[index_metadata],
     )
 
     loader = whale_loader.WhaleLoader()

--- a/pipelines/tests/unit/loader/test_whale_loader.py
+++ b/pipelines/tests/unit/loader/test_whale_loader.py
@@ -7,6 +7,7 @@ from pyhocon import ConfigFactory
 from typing import Dict, Iterable, Any, Callable  # noqa: F401
 
 from whale.models.table_metadata import TableMetadata
+from whale.models.index_metadata import IndexMetadata
 from whale.loader import whale_loader
 from whale.utils import paths
 
@@ -74,3 +75,31 @@ def test_load_catalog_specified(patched_config):
     assert "mock_table" in written_record
     assert "mock_catalog" in written_record
     assert "mock_database" in written_record
+
+def test_load_index_metadata(patched_config):
+    record = IndexMetadata(
+        database="mock_database",
+        cluster="mock_catalog",
+        schema="mock_schema",
+        table="mock_table",
+        name="mock_index",
+        columns=['mock_column_1', 'mock_column_2'],
+    )
+
+    loader = whale_loader.WhaleLoader()
+    loader.init(patched_config)
+    loader.load(record)
+
+    loader.close()
+    file_path = os.path.join(
+        patched_config.get("base_directory"),
+        "mock_database/mock_catalog.mock_schema.mock_table.md",
+    )
+    with open(file_path, "r") as f:
+        written_record = f.read()
+
+    assert "mock_schema" in written_record
+    assert "mock_table" in written_record
+    assert "mock_catalog" in written_record
+    assert "mock_database" in written_record
+    assert "mock_index" in written_record

--- a/pipelines/tests/unit/models/test_index_metadata.py
+++ b/pipelines/tests/unit/models/test_index_metadata.py
@@ -1,0 +1,41 @@
+import logging
+import unittest
+
+from whale.models.index_metadata import IndexMetadata
+from whale.models.table_metadata import ColumnMetadata
+
+
+class TestIndexMetadata(unittest.TestCase):
+    def setUp(self) -> None:
+        logging.basicConfig(level=logging.INFO)
+
+    def test_index_without_any_type(self):
+        index_metadata = IndexMetadata(
+            database="test_database",
+            cluster="test_cluster",
+            schema="test_schema",
+            table="test_table",
+            name="test_index",
+            columns=["test_column_1", "test_column_2"],
+        )
+
+        expected = "* [] `test_index` [`test_column_1`, `test_column_2`]"
+
+        self.assertEqual(index_metadata.format_for_markdown(), expected)
+
+    def test_index_with_type(self):
+        index_metadata = IndexMetadata(
+            database="test_database",
+            cluster="test_cluster",
+            schema="test_schema",
+            table="test_table",
+            name="test_index",
+            columns=["test_column_1", "test_column_2"],
+            index_type="primary",
+            architecture="clustered",
+            constraint="unique",
+        )
+
+        expected = "* [primary, unique, clustered] `test_index` [`test_column_1`, `test_column_2`]"
+
+        self.assertEqual(index_metadata.format_for_markdown(), expected)

--- a/pipelines/tests/unit/models/test_index_metadata.py
+++ b/pipelines/tests/unit/models/test_index_metadata.py
@@ -1,8 +1,81 @@
 import logging
 import unittest
 
-from whale.models.index_metadata import IndexMetadata
+from whale.models.index_metadata import TableIndexesMetadata, IndexMetadata
 from whale.models.table_metadata import ColumnMetadata
+
+
+class TestTableIndexesMetadata(unittest.TestCase):
+    def setUp(self) -> None:
+        logging.basicConfig(level=logging.INFO)
+
+    def test_single_index_without_any_type(self):
+        index_metadata = IndexMetadata(
+            name="test_index",
+            columns=["test_column_1", "test_column_2"],
+        )
+
+        table_indexes_metadata = TableIndexesMetadata(
+            database="test_database",
+            cluster="test_cluster",
+            schema="test_schema",
+            table="test_table",
+            indexes=[index_metadata],
+        )
+
+        expected = "* [] `test_index` [`test_column_1`, `test_column_2`]"
+
+        self.assertEqual(table_indexes_metadata.format_for_markdown(), expected)
+
+    def test_single_index_with_type(self):
+        index_metadata = IndexMetadata(
+            name="test_index",
+            columns=["test_column_1", "test_column_2"],
+            index_type="primary",
+            architecture="clustered",
+            constraint="unique",
+        )
+
+        table_indexes_metadata = TableIndexesMetadata(
+            database="test_database",
+            cluster="test_cluster",
+            schema="test_schema",
+            table="test_table",
+            indexes=[index_metadata],
+        )
+
+        expected = "* [primary, unique, clustered] `test_index` [`test_column_1`, `test_column_2`]"
+
+        self.assertEqual(table_indexes_metadata.format_for_markdown(), expected)
+
+    def test_multiple_indexes(self):
+        index_metadata_without_type = IndexMetadata(
+            name="test_index",
+            columns=["test_column_1", "test_column_2"],
+        )
+
+        index_metadata_with_type = IndexMetadata(
+            name="test_index",
+            columns=["test_column_1", "test_column_2"],
+            index_type="primary",
+            architecture="clustered",
+            constraint="unique",
+        )
+
+        table_indexes_metadata = TableIndexesMetadata(
+            database="test_database",
+            cluster="test_cluster",
+            schema="test_schema",
+            table="test_table",
+            indexes=[index_metadata_without_type, index_metadata_with_type],
+        )
+
+        expected_list = [
+            "* [] `test_index` [`test_column_1`, `test_column_2`]",
+            "* [primary, unique, clustered] `test_index` [`test_column_1`, `test_column_2`]",
+        ]
+
+        self.assertEqual(table_indexes_metadata.format_for_markdown(), "\n".join(expected_list))
 
 
 class TestIndexMetadata(unittest.TestCase):
@@ -11,10 +84,6 @@ class TestIndexMetadata(unittest.TestCase):
 
     def test_index_without_any_type(self):
         index_metadata = IndexMetadata(
-            database="test_database",
-            cluster="test_cluster",
-            schema="test_schema",
-            table="test_table",
             name="test_index",
             columns=["test_column_1", "test_column_2"],
         )
@@ -25,10 +94,6 @@ class TestIndexMetadata(unittest.TestCase):
 
     def test_index_with_type(self):
         index_metadata = IndexMetadata(
-            database="test_database",
-            cluster="test_cluster",
-            schema="test_schema",
-            table="test_table",
             name="test_index",
             columns=["test_column_1", "test_column_2"],
             index_type="primary",

--- a/pipelines/tests/unit/utils/test_extractor_wrappers.py
+++ b/pipelines/tests/unit/utils/test_extractor_wrappers.py
@@ -3,6 +3,7 @@ import google
 import googleapiclient
 import google_auth_httplib2
 import http
+from pydoc import locate
 
 from mock import patch
 
@@ -127,3 +128,12 @@ def test_configure_neo4j_extractor(mock_settings):
     extractor = extractors[0]
     scoped_conf = Scoped.get_scoped_conf(conf, extractor.get_scope())
     assert extractor.init(scoped_conf) == None
+
+
+def test_add_indexes_adds_index_to_postgres_extractor(*mock_settings):
+    extractors, conf = configure_postgres_extractors(TEST_POSTGRES_CONNECTION_CONFIG)
+    index_type = locate('whale.extractor.postgres_index_extractor.PostgresIndexExtractor')
+
+    extractor_is_index = [isinstance(extr, index_type) for extr in extractors]
+    assert extractor_is_index.count(True) == 1
+

--- a/pipelines/whale/extractor/base_index_extractor.py
+++ b/pipelines/whale/extractor/base_index_extractor.py
@@ -1,0 +1,106 @@
+import logging
+import os
+from datetime import datetime
+from pyhocon import ConfigFactory
+import subprocess
+import yaml
+from databuilder import Scoped
+from typing import Iterator, Union, Dict, Any
+from itertools import groupby
+
+from whale.utils.paths import METADATA_PATH
+from whale.utils import get_table_info_from_path
+from whale.utils.sql import template_query
+from whale.utils.parsers import (
+    parse_ugc,
+    sections_from_markdown,
+    DEFINED_METRICS_SECTION,
+)
+from whale.engine.sql_alchemy_engine import SQLAlchemyEngine
+from whale.models.index_metadata import IndexMetadata
+
+from databuilder.extractor.sql_alchemy_extractor import SQLAlchemyExtractor
+from databuilder.extractor.base_extractor import Extractor
+
+SQLALCHEMY_ENGINE_SCOPE = SQLAlchemyEngine().get_scope()
+SQLALCHEMY_CONN_STRING_KEY = (
+    f"{SQLALCHEMY_ENGINE_SCOPE}.{SQLAlchemyEngine.CONN_STRING_KEY}"
+)
+
+
+LOGGER = logging.getLogger(__name__)
+
+
+class IndexExtractor(Extractor):
+    """Base Index Extractor
+    SQL language-specific classes should inherit from this class, but
+    this class should not be called by itself.
+    """
+
+    # CONFIG KEYS
+    WHERE_CLAUSE_SUFFIX_KEY = "where_clause_suffix"
+    CLUSTER_KEY = "cluster_key"
+    USE_CATALOG_AS_CLUSTER_NAME = "use_catalog_as_cluster_name"
+    DATABASE_KEY = "database_key"
+    CONN_STRING_KEY = "conn_string"
+
+    # Default values
+    DEFAULT_CLUSTER_NAME = "master"
+
+    DEFAULT_CONFIG = ConfigFactory.from_dict(
+        {
+            WHERE_CLAUSE_SUFFIX_KEY: "",
+            CLUSTER_KEY: DEFAULT_CLUSTER_NAME,
+            USE_CATALOG_AS_CLUSTER_NAME: True,
+            SQLALCHEMY_CONN_STRING_KEY: None,
+        }
+    )
+
+    def init(self, conf):
+        conf = conf.with_fallback(self.DEFAULT_CONFIG)
+
+        self._cluster = "{}".format(conf.get_string(self.CLUSTER_KEY))
+
+        self._database = conf.get_string(self.DATABASE_KEY)
+
+        self.sql_stmt = self._get_sql_statement(
+            use_catalog_as_cluster_name=conf.get_bool(self.USE_CATALOG_AS_CLUSTER_NAME),
+            where_clause_suffix=conf.get_string(self.WHERE_CLAUSE_SUFFIX_KEY),
+        )
+
+        self._alchemy_extractor = SQLAlchemyExtractor()
+
+        sql_alch_conf = Scoped.get_scoped_conf(
+            conf, SQLALCHEMY_ENGINE_SCOPE
+        ).with_fallback(
+            ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt})
+        )
+
+        self.sql_stmt = sql_alch_conf.get_string(SQLAlchemyExtractor.EXTRACT_SQL)
+
+        LOGGER.info("SQL for postgres metadata: %s", self.sql_stmt)
+
+        self._alchemy_extractor.init(sql_alch_conf)
+        self._extract_iter: Union[None, iterator] = None
+
+    def extract(self):
+        if not self._extract_iter:
+            self._extract_iter = self._get_extract_iter()
+        try:
+            extraction = next(self._extract_iter)
+            return extraction
+        except StopIteration:
+            return None
+
+    def _get_raw_extract_iter(self) -> Iterator[Dict[str, Any]]:
+        """
+        Provides iterator of result row from SQLAlchemy extractor
+        :return:
+        """
+        row = self._alchemy_extractor.extract()
+        while row:
+            yield row
+            row = self._alchemy_extractor.extract()
+
+    def get_scope(self):
+        return "extractor.markdown_index"

--- a/pipelines/whale/extractor/base_postgres_metadata_extractor.py
+++ b/pipelines/whale/extractor/base_postgres_metadata_extractor.py
@@ -15,7 +15,7 @@ from databuilder.models.table_metadata import TableMetadata, ColumnMetadata
 from itertools import groupby
 
 
-TableKey = namedtuple('TableKey', ['schema', 'table_name'])
+TableKey = namedtuple("TableKey", ["schema", "table_name"])
 
 LOGGER = logging.getLogger(__name__)
 
@@ -26,20 +26,26 @@ class BasePostgresMetadataExtractor(Extractor):
     """
 
     # CONFIG KEYS
-    WHERE_CLAUSE_SUFFIX_KEY = 'where_clause_suffix'
-    CLUSTER_KEY = 'cluster_key'
-    USE_CATALOG_AS_CLUSTER_NAME = 'use_catalog_as_cluster_name'
-    DATABASE_KEY = 'database_key'
+    WHERE_CLAUSE_SUFFIX_KEY = "where_clause_suffix"
+    CLUSTER_KEY = "cluster_key"
+    USE_CATALOG_AS_CLUSTER_NAME = "use_catalog_as_cluster_name"
+    DATABASE_KEY = "database_key"
 
     # Default values
-    DEFAULT_CLUSTER_NAME = 'master'
+    DEFAULT_CLUSTER_NAME = "master"
 
     DEFAULT_CONFIG = ConfigFactory.from_dict(
-        {WHERE_CLAUSE_SUFFIX_KEY: ' ', CLUSTER_KEY: DEFAULT_CLUSTER_NAME, USE_CATALOG_AS_CLUSTER_NAME: True}
+        {
+            WHERE_CLAUSE_SUFFIX_KEY: " ",
+            CLUSTER_KEY: DEFAULT_CLUSTER_NAME,
+            USE_CATALOG_AS_CLUSTER_NAME: True,
+        }
     )
 
     @abc.abstractmethod
-    def get_sql_statement(self, use_catalog_as_cluster_name: bool, where_clause_suffix: str) -> Any:
+    def get_sql_statement(
+        self, use_catalog_as_cluster_name: bool, where_clause_suffix: str
+    ) -> Any:
         """
         :return: Provides a record or None if no more to extract
         """
@@ -47,22 +53,33 @@ class BasePostgresMetadataExtractor(Extractor):
 
     def init(self, conf: ConfigTree) -> None:
         conf = conf.with_fallback(BasePostgresMetadataExtractor.DEFAULT_CONFIG)
-        self._cluster = '{}'.format(conf.get_string(BasePostgresMetadataExtractor.CLUSTER_KEY))
+        self._cluster = "{}".format(
+            conf.get_string(BasePostgresMetadataExtractor.CLUSTER_KEY)
+        )
 
-        self._database = conf.get_string(BasePostgresMetadataExtractor.DATABASE_KEY, default='postgres')
+        self._database = conf.get_string(
+            BasePostgresMetadataExtractor.DATABASE_KEY, default="postgres"
+        )
 
         self.sql_stmt = self.get_sql_statement(
-            use_catalog_as_cluster_name=conf.get_bool(BasePostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME),
-            where_clause_suffix=conf.get_string(BasePostgresMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY),
+            use_catalog_as_cluster_name=conf.get_bool(
+                BasePostgresMetadataExtractor.USE_CATALOG_AS_CLUSTER_NAME
+            ),
+            where_clause_suffix=conf.get_string(
+                BasePostgresMetadataExtractor.WHERE_CLAUSE_SUFFIX_KEY
+            ),
         )
 
         self._alchemy_extractor = SQLAlchemyExtractor()
-        sql_alch_conf = Scoped.get_scoped_conf(conf, self._alchemy_extractor.get_scope())\
-            .with_fallback(ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt}))
+        sql_alch_conf = Scoped.get_scoped_conf(
+            conf, self._alchemy_extractor.get_scope()
+        ).with_fallback(
+            ConfigFactory.from_dict({SQLAlchemyExtractor.EXTRACT_SQL: self.sql_stmt})
+        )
 
         self.sql_stmt = sql_alch_conf.get_string(SQLAlchemyExtractor.EXTRACT_SQL)
 
-        LOGGER.info('SQL for postgres metadata: {}'.format(self.sql_stmt))
+        LOGGER.info("SQL for postgres metadata: {}".format(self.sql_stmt))
 
         self._alchemy_extractor.init(sql_alch_conf)
         self._extract_iter: Union[None, Iterator] = None
@@ -85,14 +102,23 @@ class BasePostgresMetadataExtractor(Extractor):
 
             for row in group:
                 last_row = row
-                columns.append(ColumnMetadata(row['col_name'], row['col_description'],
-                                              row['data_type'], row['col_sort_order']))
+                columns.append(
+                    ColumnMetadata(
+                        row["col_name"],
+                        row["col_description"],
+                        row["data_type"],
+                        row["col_sort_order"],
+                    )
+                )
 
-            yield TableMetadata(self._database, last_row['cluster'],
-                                last_row['schema'],
-                                last_row['name'],
-                                last_row['description'],
-                                columns)
+            yield TableMetadata(
+                self._database,
+                last_row["cluster"],
+                last_row["schema"],
+                last_row["name"],
+                last_row["description"],
+                columns,
+            )
 
     def _get_raw_extract_iter(self) -> Iterator[Dict[str, Any]]:
         """
@@ -111,6 +137,6 @@ class BasePostgresMetadataExtractor(Extractor):
         :return:
         """
         if row:
-            return TableKey(schema=row['schema'], table_name=row['name'])
+            return TableKey(schema=row["schema"], table_name=row["name"])
 
         return None

--- a/pipelines/whale/extractor/postgres_index_extractor.py
+++ b/pipelines/whale/extractor/postgres_index_extractor.py
@@ -1,0 +1,84 @@
+from typing import Iterator, Union, Dict, Any
+from collections import namedtuple
+from itertools import groupby
+
+from whale.extractor.base_index_extractor import IndexExtractor
+from whale.models.index_metadata import IndexMetadata
+
+IndexKey = namedtuple("IndexKey", ["schema", "table", "name"])
+
+
+class PostgresIndexExtractor(IndexExtractor):
+    def _get_sql_statement(
+        self, use_catalog_as_cluster_name: bool, where_clause_suffix: str = ""
+    ) -> str:
+
+        cluster_source = (
+            "c.table_catalog" if use_catalog_as_cluster_name else self._cluster
+        )
+
+        if where_clause_suffix == "":
+            where_clause_suffix = "WHERE TRUE"
+
+        return """
+        SELECT
+            {cluster_source} AS cluster,
+            n.nspname AS schema,
+            t.relname AS table,
+            i.relname AS index_name,
+            ix.indisunique AS is_unique,
+            ix.indisprimary AS is_primary,
+            ix.indisclustered AS is_clustered,
+            a.attname AS column_name
+
+        FROM pg_catalog.pg_class t
+        JOIN
+          pg_catalog.pg_index ix ON t.oid = ix.indrelid
+        JOIN
+          pg_catalog.pg_class i ON i.oid = ix.indexrelid
+        JOIN
+          pg_catalog.pg_attribute a ON a.attrelid = t.oid AND a.attnum = ANY(ix.indkey)
+        JOIN
+          pg_catalog.pg_namespace n ON n.oid = t.relnamespace
+        JOIN
+          information_schema.columns c ON c.table_schema=n.nspname AND c.table_name = t.relname AND c.column_name = a.attname
+
+        {where_clause_suffix}
+        AND t.relkind = 'r'
+        ORDER BY t.relname, i.relname;
+        """.format(
+            cluster_source=cluster_source,
+            where_clause_suffix=where_clause_suffix,
+        )
+
+    def _get_extract_iter(self):
+        for key, group in groupby(self._get_raw_extract_iter(), self._get_index_key):
+            columns = []
+            for row in group:
+                last_row = row
+                columns.append(row["column_name"])
+
+            yield IndexMetadata(
+                database=self._database,
+                cluster=last_row["cluster"],
+                schema=last_row["schema"],
+                table=last_row["table"],
+                name=last_row["index_name"],
+                index_type="primary" if last_row["is_primary"] else None,
+                architecture="clustered" if last_row["is_clustered"] else None,
+                constraint="unique" if last_row["is_unique"] else None,
+                columns=columns,
+            )
+
+    def _get_index_key(self, row: Dict[str, Any]) -> Union[IndexKey, None]:
+        """
+        Table key consists of schema and table name
+        :param row:
+        :return:
+        """
+        if not row:
+            return None
+
+        return IndexKey(
+            schema=row["schema"], table=row["table"], name=row["index_name"]
+        )

--- a/pipelines/whale/loader/whale_loader.py
+++ b/pipelines/whale/loader/whale_loader.py
@@ -22,7 +22,7 @@ from whale.utils.parsers import (
     sections_from_markdown,
 )
 import whale.models.table_metadata as metadata_model_whale
-from whale.models.index_metadata import IndexMetadata
+from whale.models.index_metadata import TableIndexesMetadata
 from whale.models.metric_value import MetricValue
 from databuilder.models.watermark import Watermark
 from databuilder.models.table_metadata import DescriptionMetadata
@@ -76,7 +76,7 @@ class WhaleLoader(Loader):
         if not record:
             return
 
-        if type(record) in [MetricValue, Watermark, IndexMetadata]:
+        if type(record) in [MetricValue, Watermark, TableIndexesMetadata]:
             table = record.table
         else:
             table = record.name
@@ -138,7 +138,7 @@ def update_markdown(file_path, record):
     section_methods = {
         MetricValue: _update_metric,
         Watermark: _update_watermark,
-        IndexMetadata: _update_index_metadata,
+        TableIndexesMetadata: _update_index_metadata,
         metadata_model_whale.TableMetadata: _update_table_metadata,
         metadata_model_amundsen.TableMetadata: _update_table_metadata,
     }
@@ -216,10 +216,9 @@ def _update_table_metadata(sections, record):
 
 
 def _update_index_metadata(sections, record):
-    if not sections[INDEX_SECTION]:
-        sections[INDEX_SECTION] = INDEX_DELIMITER + "\n"
-
-    sections[INDEX_SECTION] += record.format_for_markdown() + "\n"
+    sections[INDEX_SECTION] = (
+        INDEX_DELIMITER + "\n" + record.format_for_markdown() + "\n"
+    )
 
     return sections
 

--- a/pipelines/whale/loader/whale_loader.py
+++ b/pipelines/whale/loader/whale_loader.py
@@ -22,6 +22,7 @@ from whale.utils.parsers import (
     sections_from_markdown,
 )
 import whale.models.table_metadata as metadata_model_whale
+from whale.models.index_metadata import IndexMetadata
 from whale.models.metric_value import MetricValue
 from databuilder.models.watermark import Watermark
 from databuilder.models.table_metadata import DescriptionMetadata
@@ -29,6 +30,7 @@ import databuilder.models.table_metadata as metadata_model_amundsen
 
 from whale.utils.markdown_delimiters import (
     COLUMN_DETAILS_DELIMITER,
+    INDEX_DELIMITER,
     METRICS_DELIMITER,
     PARTITIONS_DELIMITER,
     TAGS_DELIMITER,
@@ -37,6 +39,7 @@ from whale.utils.markdown_delimiters import (
 from whale.utils.parsers import (
     HEADER_SECTION,
     COLUMN_DETAILS_SECTION,
+    INDEX_SECTION,
     PARTITION_SECTION,
     UGC_SECTION,
     METRICS_SECTION,
@@ -73,7 +76,7 @@ class WhaleLoader(Loader):
         if not record:
             return
 
-        if type(record) in [MetricValue, Watermark]:
+        if type(record) in [MetricValue, Watermark, IndexMetadata]:
             table = record.table
         else:
             table = record.name
@@ -135,6 +138,7 @@ def update_markdown(file_path, record):
     section_methods = {
         MetricValue: _update_metric,
         Watermark: _update_watermark,
+        IndexMetadata: _update_index_metadata,
         metadata_model_whale.TableMetadata: _update_table_metadata,
         metadata_model_amundsen.TableMetadata: _update_table_metadata,
     }
@@ -142,6 +146,7 @@ def update_markdown(file_path, record):
     sections = sections_from_markdown(file_path)
     # The table metadata record has both a header and column details. Add
     # custom logic to handle both.
+
     section_method = section_methods[type(record)]
     sections = section_method(sections, record)
 
@@ -206,6 +211,15 @@ def _update_table_metadata(sections, record):
     # sections[TAGS_DELIMITER] = (
     #     TAGS_DELIMITER + tag_blob + "\n"
     # )
+
+    return sections
+
+
+def _update_index_metadata(sections, record):
+    if not sections[INDEX_SECTION]:
+        sections[INDEX_SECTION] = INDEX_DELIMITER + "\n"
+
+    sections[INDEX_SECTION] += record.format_for_markdown() + "\n"
 
     return sections
 

--- a/pipelines/whale/models/index_metadata.py
+++ b/pipelines/whale/models/index_metadata.py
@@ -1,0 +1,96 @@
+from typing import Dict, Iterable, List, Optional, Union
+
+from whale.models.table_metadata import ColumnMetadata
+
+
+class IndexMetadata:
+    """
+    Metadata on indexes
+    """
+
+    INDEX_TEMPLATE = "* {type_list} `{name}` [{column_list}]"
+
+    def __init__(
+        self,
+        database: str,
+        cluster: str,
+        schema: str,
+        table: str,
+        name: str,
+        columns: Iterable[str],
+        description: Optional[str] = None,
+        index_type: Optional[str] = None,
+        architecture: Optional[str] = None,
+        constraint: Optional[str] = None,
+        tags: Optional[Union[List[Dict], List[str]]] = None,
+    ):
+        # type: (...) -> None
+        """
+        :param database: Name of the database
+        :param cluster: Name of the cluster
+        :param schema: Name of the table schema
+        :param table: Name of the table
+        :param name: Name of the index
+        :param columns: List of columns contained in the index
+        :param description: Description of the index
+        :param index_type: Type of index, e.g. primary / secondary
+        :param architecture: Index architecture, e.g. clustered / non-clustered
+        :param constraint: Constraint the index imposes, e.g. uniqueness
+        :param tags: Tag of index
+        """
+
+        self.database = database
+        self.name = name
+        self.cluster = cluster
+        self.schema = schema
+        self.table = table
+        self.description = description
+        self.index_type = index_type
+        self.architecture = architecture
+        self.constraint = constraint
+        self.columns = columns
+        self.tags = tags
+
+    def __repr__(self):
+        # type: () -> str
+        return "IndexMetadata({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})".format(
+            self.database,
+            self.cluster,
+            self.schema,
+            self.table,
+            self.name,
+            self.description,
+            self.index_type,
+            self.architecture,
+            self.constraint,
+            self.columns,
+            self.tags,
+        )
+
+    def format_for_markdown(self):
+        type_list = []
+
+        if self.index_type:
+            type_list.append(self.index_type)
+
+        if self.constraint:
+            type_list.append(self.constraint)
+
+        if self.architecture:
+            type_list.append(self.architecture)
+
+        type_list_concat = "[" + ", ".join(type_list) + "]"
+        column_list_concat = ", ".join(
+            ["`{column}`".format(column=column) for column in self.columns]
+        )
+
+        formatted_index = self.INDEX_TEMPLATE.format(
+            type_list=type_list_concat,
+            name=self.name,
+            column_list=column_list_concat,
+        )
+
+        formatted_indexes_list = []
+        formatted_indexes_list.append(formatted_index)
+
+        return "\n".join(formatted_indexes_list)

--- a/pipelines/whale/models/index_metadata.py
+++ b/pipelines/whale/models/index_metadata.py
@@ -12,10 +12,6 @@ class IndexMetadata:
 
     def __init__(
         self,
-        database: str,
-        cluster: str,
-        schema: str,
-        table: str,
         name: str,
         columns: Iterable[str],
         description: Optional[str] = None,
@@ -26,10 +22,6 @@ class IndexMetadata:
     ):
         # type: (...) -> None
         """
-        :param database: Name of the database
-        :param cluster: Name of the cluster
-        :param schema: Name of the table schema
-        :param table: Name of the table
         :param name: Name of the index
         :param columns: List of columns contained in the index
         :param description: Description of the index
@@ -39,31 +31,23 @@ class IndexMetadata:
         :param tags: Tag of index
         """
 
-        self.database = database
         self.name = name
-        self.cluster = cluster
-        self.schema = schema
-        self.table = table
+        self.columns = columns
         self.description = description
         self.index_type = index_type
         self.architecture = architecture
         self.constraint = constraint
-        self.columns = columns
         self.tags = tags
 
     def __repr__(self):
         # type: () -> str
-        return "IndexMetadata({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})".format(
-            self.database,
-            self.cluster,
-            self.schema,
-            self.table,
+        return "IndexMetadata({!r}, {!r}, {!r}, {!r}, {!r}, {!r}, {!r})".format(
             self.name,
+            self.columns,
             self.description,
             self.index_type,
             self.architecture,
             self.constraint,
-            self.columns,
             self.tags,
         )
 
@@ -90,7 +74,48 @@ class IndexMetadata:
             column_list=column_list_concat,
         )
 
-        formatted_indexes_list = []
-        formatted_indexes_list.append(formatted_index)
+        return formatted_index
 
-        return "\n".join(formatted_indexes_list)
+
+class TableIndexesMetadata:
+    """
+    Contains the list of indexes for a given table
+    """
+
+    def __init__(
+        self,
+        database: str,
+        cluster: str,
+        schema: str,
+        table: str,
+        indexes: Iterable[IndexMetadata],
+    ):
+        # type: (...) -> None
+        """
+        :param database: Name of the database
+        :param cluster: Name of the cluster
+        :param schema: Name of the table schema
+        :param table: Name of the table
+        :param indexes: Iterable of indexes
+        """
+
+        self.database = database
+        self.cluster = cluster
+        self.schema = schema
+        self.table = table
+        self.indexes = indexes
+
+    def __repr__(self):
+        # type: () -> str
+        return "IndexMetadata({!r}, {!r}, {!r}, {!r}, {!r})".format(
+            self.database,
+            self.cluster,
+            self.schema,
+            self.table,
+            self.indexes,
+        )
+
+    def format_for_markdown(self):
+        formatted_indexes = [index.format_for_markdown() for index in self.indexes]
+
+        return "\n".join(formatted_indexes)

--- a/pipelines/whale/utils/markdown_delimiters.py
+++ b/pipelines/whale/utils/markdown_delimiters.py
@@ -1,4 +1,5 @@
 COLUMN_DETAILS_DELIMITER = "## Column details"
+INDEX_DELIMITER = "## Indexes"
 PARTITIONS_DELIMITER = "## Partition info"
 USAGE_DELIMITER = "## Usage info"
 UGC_DELIMITER = "-" * 79

--- a/pipelines/whale/utils/parsers.py
+++ b/pipelines/whale/utils/parsers.py
@@ -1,6 +1,7 @@
 import re
 from whale.utils.markdown_delimiters import (
     COLUMN_DETAILS_DELIMITER,
+    INDEX_DELIMITER,
     DEFINED_METRICS_DELIMITER,
     METRICS_DELIMITER,
     BLOCK_END_DELIMITER,
@@ -12,6 +13,7 @@ from whale.utils.markdown_delimiters import (
 
 HEADER_SECTION = "header"
 COLUMN_DETAILS_SECTION = "column_details"
+INDEX_SECTION = "index"
 PARTITION_SECTION = "partition"
 USAGE_SECTION = "usage"
 UGC_SECTION = "ugc"
@@ -25,6 +27,8 @@ def parse_programmatic_blob(programmatic_blob):
     regex_to_match = (
         "("
         + COLUMN_DETAILS_DELIMITER
+        + "|"
+        + INDEX_DELIMITER
         + "|"
         + PARTITIONS_DELIMITER
         + "|"
@@ -40,6 +44,7 @@ def parse_programmatic_blob(programmatic_blob):
     sections = {
         HEADER_SECTION: [],
         COLUMN_DETAILS_SECTION: [],
+        INDEX_SECTION: [],
         PARTITION_SECTION: [],
         USAGE_SECTION: [],
         METRICS_SECTION: [],
@@ -48,6 +53,8 @@ def parse_programmatic_blob(programmatic_blob):
     for clause in splits:
         if clause == COLUMN_DETAILS_DELIMITER:
             state = COLUMN_DETAILS_SECTION
+        elif clause == INDEX_DELIMITER:
+            state = INDEX_SECTION
         elif clause == PARTITIONS_DELIMITER:
             state = PARTITION_SECTION
         elif clause == USAGE_DELIMITER:
@@ -148,6 +155,7 @@ def markdown_from_sections(sections: dict):
     programmatic_blob = (
         sections[HEADER_SECTION]
         + sections[COLUMN_DETAILS_SECTION]
+        + sections[INDEX_SECTION]
         + sections[PARTITION_SECTION]
         + sections[USAGE_SECTION]
         + sections[METRICS_SECTION]


### PR DESCRIPTION
This PR adds the ability to scrape index metadata of a PostgreSQL instance, like this:
![image](https://user-images.githubusercontent.com/52512373/107977703-8a835e80-6f89-11eb-9980-3842e594b26b.png)

### Structure of the code:
- I add `add_indexes` to `configure_bigquery_extractor`, which adds index information to the table metadata.
- `add_indexes` adds `PostgresIndexExtractor` as an additional extractor. This is done via a dict, meaning it will be easy to add a e.g. `BigQueryIndexExtractor`.
- `PostgresIndexExtractor` inherits from `IndexExtractor` and expands on `IndexExtractor` by a SQL query that gets all the index information we need, e.g. a list of indexes incl. name & which columns are included in an index.
- `IndexExtractor` itself contains mostly boilerplate code to initiate a connection and interact with the iterator and `SQLAlchemyEngine`.
- Inside `WhaleLoader` `PostgresIndexExtractor` is run, since it was added to the list of extractors through `add_indexes`. 
- `IndexMetadata` is the index class, which stores all information contained inside an index.
- Similar to https://github.com/dataframehq/whale/pull/143 I added a `format_for_markdown` function to `IndexMetadata`, where the index is transformed into a string like ```[unique] `index_name` [`column_1`, `column_2`]```

### What will be left for future PRs:
- I think it would be helpful to also add information if an index is a primary key.
- This PR only adds the ability for PostgreSQL to see indexes. All other SQL dialects should be worked on next.