### PR TITLE
Add hyphen required by Cargo in package version

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "whale"
-version = "2.0.0b0"
+version = "2.0.0-b0"
 authors = ["Robert Yi <robert@dataframe.ai>"]
 edition = "2018"
 

--- a/cli/src/skimmer.rs
+++ b/cli/src/skimmer.rs
@@ -50,7 +50,7 @@ fn command_is_installed(command: &str) -> bool {
 
 fn read_file_to_string(file_path: &str) -> String {
     fs::read_to_string(file_path)
-        .unwrap_or_else(|_| panic!(format!("failed to read path: {}", file_path)))
+        .unwrap_or_else(|_| panic!("{}", format!("failed to read path: {}", file_path)))
 }
 
 // TODO: I don't like this name - how to clean this up?


### PR DESCRIPTION
Add dash required by Cargo in package version

Please see [issue](https://github.com/dataframehq/whale/issues/158)

Cargo appears to require a hyphen in between the patch version and the pre release identifiers.

Any advice or suggestion is more than welcome.

Thanks