### PR TITLE
Fix Slack tests

### DIFF
--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -1,6 +1,5 @@
 # whale-pipelines
 
-# Triggering CI
 whale-pipelines is a library based on amundsen's databuilder that enables easy extraction of metadata into whale's markdown format. The library references static config files in `~/.whale/` to establish connections and customize the scraping process. Whale also provides hooks into SQLAlchemy for easy execution of SQL queries against these locally defined connections, without having to specify connection strings at every request.
 
 For information on the full CLI platform, visit [whale](https://github.com/dataframehq/whale).

--- a/pipelines/README.md
+++ b/pipelines/README.md
@@ -1,5 +1,6 @@
 # whale-pipelines
 
+# Triggering CI
 whale-pipelines is a library based on amundsen's databuilder that enables easy extraction of metadata into whale's markdown format. The library references static config files in `~/.whale/` to establish connections and customize the scraping process. Whale also provides hooks into SQLAlchemy for easy execution of SQL queries against these locally defined connections, without having to specify connection strings at every request.
 
 For information on the full CLI platform, visit [whale](https://github.com/dataframehq/whale).


### PR DESCRIPTION
When CI ran in an earlier merge, it failed. From https://github.com/dataframehq/whale/runs/2622524391:
```
>           raise RuntimeError(_request_ctx_err_msg)
E           RuntimeError: Working outside of request context.
E           
E           This typically means that you attempted to use functionality that needed
E           an active HTTP request.  Consult the documentation on testing for
E           information about how to avoid this problem.
```

Locally I was never able to reproduce the error, but it seems that we need to create a Flask context first to access anything about the request. This is done with `test_request_context`. Since this environment is even more contained, I think the only way to test code is to manually call the method being called on this specific route.