### PR TITLE
Add brew install location to docs for clarity

### DIFF
--- a/docs/features/running-sql-queries.md
+++ b/docs/features/running-sql-queries.md
@@ -107,6 +107,11 @@ Add the following to your `.vimrc` file, and you can run `<Leader>wh` to execute
 nmap <Leader>wh :w<CR>:exec '!~/.whale/bin/whale run %'<CR>:e<CR>
 ```
 
+Or if installed via Homebrew:
+```text
+nmap <Leader>wh :w<CR>:exec '!/usr/local/bin/wh run %'<CR>:e<CR>
+```
+
 #### Vscode
 
 TODO


### PR DESCRIPTION
Brew sticks the binary in a different place, felt worth calling out as it tripped me up for a sec when i was copypasta'ing this -- considered doing something like {bin location} adding context around the possibilities there but that seemed more confusing tbh